### PR TITLE
Conformance to swift style guide

### DIFF
--- a/CleanStore.xcodeproj/project.pbxproj
+++ b/CleanStore.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		44D61FA71C5230E0000E5DEF /* ListOrdersViewControllerTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D61FA61C5230E0000E5DEF /* ListOrdersViewControllerTableView.swift */; };
 		710475381B882CA000D72E3C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710475371B882CA000D72E3C /* AppDelegate.swift */; };
 		7104753D1B882CA000D72E3C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7104753B1B882CA000D72E3C /* Main.storyboard */; };
 		7104753F1B882CA000D72E3C /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7104753E1B882CA000D72E3C /* Images.xcassets */; };
@@ -58,6 +59,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		44D61FA61C5230E0000E5DEF /* ListOrdersViewControllerTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ListOrdersViewControllerTableView.swift; path = ListOrders/ListOrdersViewControllerTableView.swift; sourceTree = "<group>"; };
 		710475321B882CA000D72E3C /* CleanStore.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CleanStore.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		710475361B882CA000D72E3C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		710475371B882CA000D72E3C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				71B2CCE31BE547CA00C734CA /* ListOrdersRouter.swift */,
 				71B2CCE41BE547CA00C734CA /* ListOrdersViewController.swift */,
 				71B2CCE51BE547CA00C734CA /* ListOrdersWorker.swift */,
+				44D61FA61C5230E0000E5DEF /* ListOrdersViewControllerTableView.swift */,
 			);
 			name = ListOrders;
 			sourceTree = "<group>";
@@ -421,6 +424,7 @@
 				71B2CCF01BE547CA00C734CA /* ListOrdersViewController.swift in Sources */,
 				71B2CCEE1BE547CA00C734CA /* ListOrdersRouter.swift in Sources */,
 				718697481B8D8B94004E4CD9 /* CreateOrderRouter.swift in Sources */,
+				44D61FA71C5230E0000E5DEF /* ListOrdersViewControllerTableView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CleanStore.xcodeproj/project.pbxproj
+++ b/CleanStore.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		44D61FA71C5230E0000E5DEF /* ListOrdersViewControllerTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D61FA61C5230E0000E5DEF /* ListOrdersViewControllerTableView.swift */; };
+		44D61FA91C523F2F000E5DEF /* CreateOrderViewControllerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D61FA81C523F2F000E5DEF /* CreateOrderViewControllerTextField.swift */; };
+		44D61FAB1C523F7D000E5DEF /* CreateOrderViewControllerPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D61FAA1C523F7D000E5DEF /* CreateOrderViewControllerPickerView.swift */; };
 		710475381B882CA000D72E3C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710475371B882CA000D72E3C /* AppDelegate.swift */; };
 		7104753D1B882CA000D72E3C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7104753B1B882CA000D72E3C /* Main.storyboard */; };
 		7104753F1B882CA000D72E3C /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7104753E1B882CA000D72E3C /* Images.xcassets */; };
@@ -60,6 +62,8 @@
 
 /* Begin PBXFileReference section */
 		44D61FA61C5230E0000E5DEF /* ListOrdersViewControllerTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ListOrdersViewControllerTableView.swift; path = ListOrders/ListOrdersViewControllerTableView.swift; sourceTree = "<group>"; };
+		44D61FA81C523F2F000E5DEF /* CreateOrderViewControllerTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateOrderViewControllerTextField.swift; sourceTree = "<group>"; };
+		44D61FAA1C523F7D000E5DEF /* CreateOrderViewControllerPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateOrderViewControllerPickerView.swift; sourceTree = "<group>"; };
 		710475321B882CA000D72E3C /* CleanStore.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CleanStore.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		710475361B882CA000D72E3C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		710475371B882CA000D72E3C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -234,6 +238,8 @@
 				7186973D1B8D8B94004E4CD9 /* CreateOrderRouter.swift */,
 				7186973E1B8D8B94004E4CD9 /* CreateOrderViewController.swift */,
 				7186973F1B8D8B94004E4CD9 /* CreateOrderWorker.swift */,
+				44D61FA81C523F2F000E5DEF /* CreateOrderViewControllerTextField.swift */,
+				44D61FAA1C523F7D000E5DEF /* CreateOrderViewControllerPickerView.swift */,
 			);
 			path = CreateOrder;
 			sourceTree = "<group>";
@@ -401,6 +407,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44D61FAB1C523F7D000E5DEF /* CreateOrderViewControllerPickerView.swift in Sources */,
+				44D61FA91C523F2F000E5DEF /* CreateOrderViewControllerTextField.swift in Sources */,
 				716B29391BEECAC9005986B1 /* ManagedOrder+CoreDataProperties.swift in Sources */,
 				718697461B8D8B94004E4CD9 /* CreateOrderPresenter.swift in Sources */,
 				710475381B882CA000D72E3C /* AppDelegate.swift in Sources */,

--- a/CleanStore/AppDelegate.swift
+++ b/CleanStore/AppDelegate.swift
@@ -9,40 +9,33 @@
 import UIKit
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate
-{
+class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
   
-  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool
-  {
+  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
     // Override point for customization after application launch.
     return true
   }
   
-  func applicationWillResignActive(application: UIApplication)
-  {
+  func applicationWillResignActive(application: UIApplication) {
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
     // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
   }
   
-  func applicationDidEnterBackground(application: UIApplication)
-  {
+  func applicationDidEnterBackground(application: UIApplication) {
     // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
   }
   
-  func applicationWillEnterForeground(application: UIApplication)
-  {
+  func applicationWillEnterForeground(application: UIApplication) {
     // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
   }
   
-  func applicationDidBecomeActive(application: UIApplication)
-  {
+  func applicationDidBecomeActive(application: UIApplication) {
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
   }
   
-  func applicationWillTerminate(application: UIApplication)
-  {
+  func applicationWillTerminate(application: UIApplication) {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
   }
 }

--- a/CleanStore/Base.lproj/Main.storyboard
+++ b/CleanStore/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="3zf-vf-WGz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="3zf-vf-WGz">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -12,7 +12,6 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="c2K-1y-qru">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="1010"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <sections>
                             <tableViewSection headerTitle="Customer Contact Info" id="lzw-r1-74J">
@@ -26,14 +25,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="First Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xJ4-5s-Dbu">
                                                     <rect key="frame" x="8" y="11" width="83" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6AS-fv-Dlp">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="bPQ-a1-rIc"/>
                                                         <constraint firstAttribute="width" constant="241" id="hRS-Jp-NDs"/>
@@ -45,7 +42,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="xJ4-5s-Dbu" firstAttribute="leading" secondItem="AYP-yl-2j4" secondAttribute="leadingMargin" id="KWo-7u-N9j"/>
                                                 <constraint firstItem="6AS-fv-Dlp" firstAttribute="trailing" secondItem="AYP-yl-2j4" secondAttribute="trailingMargin" id="NyY-X4-BHK"/>
@@ -53,7 +49,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="xJ4-5s-Dbu" secondAttribute="centerY" id="wYn-fh-U7v"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="Erz-9H-MzL">
                                         <rect key="frame" x="0.0" y="130" width="414" height="44"/>
@@ -64,14 +59,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Last Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Ud-qJ-Z41">
                                                     <rect key="frame" x="8" y="11" width="82" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gbW-mw-Xc0">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="tPk-YE-Bha"/>
                                                         <constraint firstAttribute="width" constant="241" id="xki-lx-fIZ"/>
@@ -83,7 +76,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="gbW-mw-Xc0" firstAttribute="trailing" secondItem="QIB-43-e5r" secondAttribute="trailingMargin" id="9SJ-1y-tqN"/>
                                                 <constraint firstItem="6Ud-qJ-Z41" firstAttribute="leading" secondItem="QIB-43-e5r" secondAttribute="leadingMargin" id="GGD-iw-Akj"/>
@@ -91,7 +83,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="gbW-mw-Xc0" secondAttribute="centerY" id="uCq-zg-pom"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="3tU-b1-h8Q">
                                         <rect key="frame" x="0.0" y="174" width="414" height="44"/>
@@ -102,14 +93,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Phone" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EmR-cG-CvV">
                                                     <rect key="frame" x="8" y="11" width="49" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="X6h-kQ-0QC">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="241" id="c0z-Ku-2LQ"/>
                                                         <constraint firstAttribute="height" constant="30" id="gGS-gs-dYT"/>
@@ -121,7 +110,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="EmR-cG-CvV" secondAttribute="centerY" id="8f3-m3-ryF"/>
                                                 <constraint firstItem="EmR-cG-CvV" firstAttribute="leading" secondItem="zeP-11-Ye0" secondAttribute="leadingMargin" id="GCq-hC-b1z"/>
@@ -129,7 +117,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="X6h-kQ-0QC" secondAttribute="centerY" id="aif-dw-w2e"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="6IN-tb-p9v">
                                         <rect key="frame" x="0.0" y="218" width="414" height="44"/>
@@ -140,14 +127,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KUn-cy-L7P">
                                                     <rect key="frame" x="8" y="11" width="41" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yBr-VC-Eb1">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="A1L-fz-OEe"/>
                                                         <constraint firstAttribute="width" constant="241" id="RG4-TG-fnO"/>
@@ -159,7 +144,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="yBr-VC-Eb1" secondAttribute="centerY" id="9Rb-8H-bJd"/>
                                                 <constraint firstAttribute="centerY" secondItem="KUn-cy-L7P" secondAttribute="centerY" id="MAO-aM-k1b"/>
@@ -167,7 +151,6 @@
                                                 <constraint firstItem="yBr-VC-Eb1" firstAttribute="trailing" secondItem="wLS-EA-aFW" secondAttribute="trailingMargin" id="btJ-Jd-yOX"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -182,14 +165,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street 1" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KOY-j4-AlZ">
                                                     <rect key="frame" x="8" y="11" width="59" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Exf-fb-QNO">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="82Q-FA-9Yb"/>
                                                         <constraint firstAttribute="width" constant="241" id="pvE-f8-Sm8"/>
@@ -201,7 +182,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="KOY-j4-AlZ" firstAttribute="leading" secondItem="poG-oL-46g" secondAttribute="leadingMargin" id="4Pf-An-lzv"/>
                                                 <constraint firstItem="Exf-fb-QNO" firstAttribute="trailing" secondItem="poG-oL-46g" secondAttribute="trailingMargin" id="KNF-ZP-7az"/>
@@ -209,7 +189,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="Exf-fb-QNO" secondAttribute="centerY" id="v69-zZ-1RA"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="fNs-Pv-YOl">
                                         <rect key="frame" x="0.0" y="328" width="414" height="44"/>
@@ -220,14 +199,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street 2" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Klq-5W-O5V">
                                                     <rect key="frame" x="8" y="11" width="61" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="B16-E1-Ld0">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="252-s8-lFX"/>
                                                         <constraint firstAttribute="width" constant="241" id="2Gb-8a-N5a"/>
@@ -239,7 +216,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="B16-E1-Ld0" firstAttribute="trailing" secondItem="Cd0-w9-NzZ" secondAttribute="trailingMargin" id="03T-bU-stB"/>
                                                 <constraint firstItem="Klq-5W-O5V" firstAttribute="leading" secondItem="Cd0-w9-NzZ" secondAttribute="leadingMargin" id="8rL-D9-kko"/>
@@ -247,7 +223,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="Klq-5W-O5V" secondAttribute="centerY" id="bun-g6-Vmf"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="OPR-Ym-Gh5">
                                         <rect key="frame" x="0.0" y="372" width="414" height="44"/>
@@ -258,14 +233,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="City" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XG5-lt-h4P">
                                                     <rect key="frame" x="8" y="11" width="31" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Z2S-H9-SSc">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="241" id="295-w8-Sfr"/>
                                                         <constraint firstAttribute="height" constant="30" id="BvQ-Ai-6at"/>
@@ -277,7 +250,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="Z2S-H9-SSc" firstAttribute="trailing" secondItem="FCe-MT-5PI" secondAttribute="trailingMargin" id="4xk-es-tIV"/>
                                                 <constraint firstAttribute="centerY" secondItem="XG5-lt-h4P" secondAttribute="centerY" id="CVA-gZ-iU6"/>
@@ -285,7 +257,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="Z2S-H9-SSc" secondAttribute="centerY" id="tk8-Pd-3dm"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="QBX-3N-Xys">
                                         <rect key="frame" x="0.0" y="416" width="414" height="44"/>
@@ -296,14 +267,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="State" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kmG-46-bTV">
                                                     <rect key="frame" x="8" y="11" width="41" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kLE-gn-mp0">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="241" id="pq4-Nw-PrL"/>
                                                         <constraint firstAttribute="height" constant="30" id="qJr-tZ-9Sh"/>
@@ -315,7 +284,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="kmG-46-bTV" secondAttribute="centerY" id="8c5-s9-BWi"/>
                                                 <constraint firstItem="kmG-46-bTV" firstAttribute="leading" secondItem="M3c-uM-mnK" secondAttribute="leadingMargin" id="X7J-gx-75P"/>
@@ -323,7 +291,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="kLE-gn-mp0" secondAttribute="centerY" id="lGM-ST-hdG"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="djd-m8-8u4">
                                         <rect key="frame" x="0.0" y="460" width="414" height="44"/>
@@ -334,14 +301,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ZIP" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dvI-Wb-E7n">
                                                     <rect key="frame" x="8" y="11" width="26" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LT8-ft-iEl">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="3Gd-e4-nxD"/>
                                                         <constraint firstAttribute="width" constant="241" id="gdz-nE-CcU"/>
@@ -353,7 +318,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="dvI-Wb-E7n" firstAttribute="leading" secondItem="WLn-uf-6rv" secondAttribute="leadingMargin" id="2gY-dM-zNI"/>
                                                 <constraint firstAttribute="centerY" secondItem="LT8-ft-iEl" secondAttribute="centerY" id="WwC-sT-7Bp"/>
@@ -361,7 +325,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="dvI-Wb-E7n" secondAttribute="centerY" id="qsl-mY-FFb"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -376,14 +339,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shipping speed" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7mD-hD-MOz">
                                                     <rect key="frame" x="8" y="11" width="119" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M4M-BZ-TNQ">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="JsV-kY-p0W"/>
                                                         <constraint firstAttribute="width" constant="241" id="stR-NC-rdv"/>
@@ -395,7 +356,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="M4M-BZ-TNQ" firstAttribute="trailing" secondItem="4lS-sD-bft" secondAttribute="trailingMargin" id="EsP-WD-BpM"/>
                                                 <constraint firstItem="7mD-hD-MOz" firstAttribute="leading" secondItem="4lS-sD-bft" secondAttribute="leadingMargin" id="JwP-6B-gSA"/>
@@ -403,7 +363,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="M4M-BZ-TNQ" secondAttribute="centerY" id="dy9-Zq-2Pf"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -418,14 +377,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Credit card number" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WJM-IC-FOq">
                                                     <rect key="frame" x="8" y="11" width="149" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="O3J-dU-zG5">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="E2M-Gh-AXF"/>
                                                     </constraints>
@@ -436,7 +393,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="O3J-dU-zG5" secondAttribute="centerY" id="5TM-gL-C1w"/>
                                                 <constraint firstItem="O3J-dU-zG5" firstAttribute="trailing" secondItem="tDk-Zc-n2B" secondAttribute="trailingMargin" id="6vu-Jf-3U7"/>
@@ -445,7 +401,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="WJM-IC-FOq" secondAttribute="centerY" id="gNx-Cm-bfC"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="MVB-ae-RmR">
                                         <rect key="frame" x="0.0" y="636" width="414" height="44"/>
@@ -456,14 +411,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Expiration date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aW4-c5-bLL">
                                                     <rect key="frame" x="8" y="11" width="115" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tvY-pa-rIH">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="241" id="J9z-La-SoG"/>
                                                         <constraint firstAttribute="height" constant="30" id="mNz-ai-xhh"/>
@@ -475,7 +428,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="aW4-c5-bLL" firstAttribute="leading" secondItem="r7w-Nl-fZE" secondAttribute="leadingMargin" id="PR9-Wh-7mg"/>
                                                 <constraint firstItem="tvY-pa-rIH" firstAttribute="trailing" secondItem="r7w-Nl-fZE" secondAttribute="trailingMargin" id="mLH-As-CVe"/>
@@ -483,7 +435,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="aW4-c5-bLL" secondAttribute="centerY" id="ut6-Wx-fja"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="pLh-Th-X7c">
                                         <rect key="frame" x="0.0" y="680" width="414" height="44"/>
@@ -494,14 +445,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CVV" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G5f-SL-u8O">
                                                     <rect key="frame" x="8" y="11" width="34" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XyJ-fe-4ME">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="4fT-PU-8EJ"/>
                                                         <constraint firstAttribute="width" constant="241" id="SvO-D7-Nfa"/>
@@ -513,7 +462,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="XyJ-fe-4ME" firstAttribute="trailing" secondItem="fyi-yi-oMi" secondAttribute="trailingMargin" id="Ois-8t-Hsu"/>
                                                 <constraint firstAttribute="centerY" secondItem="XyJ-fe-4ME" secondAttribute="centerY" id="UAz-xk-WCF"/>
@@ -521,7 +469,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="G5f-SL-u8O" secondAttribute="centerY" id="r2B-8r-FAH"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -536,17 +483,14 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Same as shipping address" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r94-4z-zu4">
                                                     <rect key="frame" x="8" y="11" width="201" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="x9B-cS-SD8">
                                                     <rect key="frame" x="357" y="6" width="51" height="31"/>
-                                                    <animations/>
                                                 </switch>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="r94-4z-zu4" firstAttribute="leading" secondItem="uBJ-0V-G4U" secondAttribute="leadingMargin" id="Dva-gO-9cz"/>
                                                 <constraint firstAttribute="centerY" secondItem="x9B-cS-SD8" secondAttribute="centerY" id="TWx-iU-gAe"/>
@@ -554,7 +498,6 @@
                                                 <constraint firstItem="x9B-cS-SD8" firstAttribute="trailing" secondItem="uBJ-0V-G4U" secondAttribute="trailingMargin" id="fPW-Sc-MA3"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="5rW-RL-waM">
                                         <rect key="frame" x="0.0" y="790" width="414" height="44"/>
@@ -565,14 +508,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street 1" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aew-JZ-yt0">
                                                     <rect key="frame" x="8" y="11" width="59" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dnr-s0-cgm">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="12A-9C-OF2"/>
                                                         <constraint firstAttribute="width" constant="241" id="ziZ-lJ-PhR"/>
@@ -584,7 +525,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="aew-JZ-yt0" firstAttribute="leading" secondItem="dwU-Lk-hN8" secondAttribute="leadingMargin" id="2rk-fQ-6n0"/>
                                                 <constraint firstItem="dnr-s0-cgm" firstAttribute="trailing" secondItem="dwU-Lk-hN8" secondAttribute="trailingMargin" id="Imv-UM-E4v"/>
@@ -592,7 +532,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="aew-JZ-yt0" secondAttribute="centerY" id="oJ5-OX-jF6"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="nHG-iz-pfb">
                                         <rect key="frame" x="0.0" y="834" width="414" height="44"/>
@@ -603,14 +542,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street 2" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zyK-32-LHZ">
                                                     <rect key="frame" x="8" y="11" width="61" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PLP-sQ-Km8">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="uCL-cN-opM"/>
                                                         <constraint firstAttribute="width" constant="241" id="xBq-YA-Vui"/>
@@ -622,7 +559,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="zyK-32-LHZ" firstAttribute="leading" secondItem="bvc-F4-2Fs" secondAttribute="leadingMargin" id="DGq-dO-aoZ"/>
                                                 <constraint firstAttribute="centerY" secondItem="zyK-32-LHZ" secondAttribute="centerY" id="LGg-dV-m3Y"/>
@@ -630,7 +566,6 @@
                                                 <constraint firstItem="PLP-sQ-Km8" firstAttribute="trailing" secondItem="bvc-F4-2Fs" secondAttribute="trailingMargin" id="jof-G2-OwU"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="cyk-oZ-fM1">
                                         <rect key="frame" x="0.0" y="878" width="414" height="44"/>
@@ -641,14 +576,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="City" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YIo-yQ-1qP">
                                                     <rect key="frame" x="8" y="11" width="31" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="P4m-gx-Kdr">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="DI0-eU-UuW"/>
                                                         <constraint firstAttribute="width" constant="241" id="HHR-8l-JbU"/>
@@ -660,7 +593,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="P4m-gx-Kdr" secondAttribute="centerY" id="5KG-CI-9q3"/>
                                                 <constraint firstItem="P4m-gx-Kdr" firstAttribute="trailing" secondItem="HZi-Bv-0y6" secondAttribute="trailingMargin" id="AEg-NT-L29"/>
@@ -668,7 +600,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="YIo-yQ-1qP" secondAttribute="centerY" id="ofG-7S-ao8"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="SaA-86-B2J">
                                         <rect key="frame" x="0.0" y="922" width="414" height="44"/>
@@ -679,14 +610,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="State" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tzF-ax-Idg">
                                                     <rect key="frame" x="8" y="11" width="41" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Xe5-Nk-o7g">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="VW7-71-1aq"/>
                                                         <constraint firstAttribute="width" constant="241" id="p7D-vN-lrz"/>
@@ -698,7 +627,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="tzF-ax-Idg" firstAttribute="leading" secondItem="hHy-2R-sIO" secondAttribute="leadingMargin" id="UKd-61-nIH"/>
                                                 <constraint firstAttribute="centerY" secondItem="Xe5-Nk-o7g" secondAttribute="centerY" id="V04-Mr-a3Z"/>
@@ -706,7 +634,6 @@
                                                 <constraint firstItem="Xe5-Nk-o7g" firstAttribute="trailing" secondItem="hHy-2R-sIO" secondAttribute="trailingMargin" id="uGm-8y-0v8"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="4nq-V3-bTi">
                                         <rect key="frame" x="0.0" y="966" width="414" height="44"/>
@@ -717,14 +644,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ZIP" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dhh-Ut-YD5">
                                                     <rect key="frame" x="8" y="11" width="26" height="21"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Dqn-Gx-fXk">
                                                     <rect key="frame" x="165" y="7" width="241" height="30"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="e9u-gb-53H"/>
                                                         <constraint firstAttribute="width" constant="241" id="eiH-La-KK5"/>
@@ -736,7 +661,6 @@
                                                     </connections>
                                                 </textField>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="Dhh-Ut-YD5" firstAttribute="leading" secondItem="iLo-6O-TYe" secondAttribute="leadingMargin" id="1rs-ki-q2B"/>
                                                 <constraint firstAttribute="centerY" secondItem="Dhh-Ut-YD5" secondAttribute="centerY" id="DXA-ra-59C"/>
@@ -744,7 +668,6 @@
                                                 <constraint firstAttribute="centerY" secondItem="Dqn-Gx-fXk" secondAttribute="centerY" id="k6V-tK-1ql"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -788,7 +711,6 @@
                 <pickerView contentMode="scaleToFill" id="vAI-q7-LSR">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="162"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <animations/>
                     <connections>
                         <outlet property="dataSource" destination="0kW-S4-ck9" id="182-Rm-fMg"/>
                         <outlet property="delegate" destination="0kW-S4-ck9" id="CCj-4D-uiX"/>
@@ -797,7 +719,6 @@
                 <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" minuteInterval="1" id="MeA-k3-vaX">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="162"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <animations/>
                     <date key="date" timeIntervalSinceReferenceDate="459961077.51814002">
                         <!--2015-07-30 14:57:57 +0000-->
                     </date>
@@ -815,7 +736,6 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="S5R-Dp-bcg">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="OrderTableViewCell" textLabel="zr4-e9-eW3" detailTextLabel="8UH-1a-U2Y" style="IBUITableViewCellStyleValue1" id="3PT-XR-S6X">
@@ -828,7 +748,6 @@
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zr4-e9-eW3">
                                             <rect key="frame" x="15" y="12" width="32" height="20"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <animations/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -836,15 +755,12 @@
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8UH-1a-U2Y">
                                             <rect key="frame" x="543" y="12" width="42" height="20"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <animations/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
-                                    <animations/>
                                 </tableViewCellContentView>
-                                <animations/>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -872,7 +788,6 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="5b6-6y-A2L">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>

--- a/CleanStore/Models/ManagedOrder.swift
+++ b/CleanStore/Models/ManagedOrder.swift
@@ -1,10 +1,8 @@
 import Foundation
 import CoreData
 
-class ManagedOrder: NSManagedObject
-{
-  func toOrder() -> Order
-  {
+class ManagedOrder: NSManagedObject {
+  func toOrder() -> Order {
     return Order(id: id, date: date, email: email, firstName: firstName, lastName: lastName, total: total)
   }
 }

--- a/CleanStore/Models/Order.swift
+++ b/CleanStore/Models/Order.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-struct Order: Equatable
-{
+struct Order: Equatable {
   var id: String?
   var date: NSDate?
   var email: String?
@@ -10,8 +9,7 @@ struct Order: Equatable
   var total: NSDecimalNumber?
 }
 
-func ==(lhs: Order, rhs: Order) -> Bool
-{
+func ==(lhs: Order, rhs: Order) -> Bool {
   var dateEqual = false
   if let lhsDate = lhs.date, rhsDate = rhs.date {
     dateEqual = lhsDate.timeIntervalSinceDate(rhsDate) < 1.0

--- a/CleanStore/Scenes/CreateOrder/CreateOrderConfigurator.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderConfigurator.swift
@@ -13,28 +13,22 @@ import UIKit
 
 // MARK: Connect View, Interactor, and Presenter
 
-extension CreateOrderViewController: CreateOrderPresenterOutput
-{
-  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?)
-  {
+extension CreateOrderViewController: CreateOrderPresenterOutput {
+  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
     router.passDataToNextScene(segue)
   }
 }
 
-extension CreateOrderInteractor: CreateOrderViewControllerOutput
-{
+extension CreateOrderInteractor: CreateOrderViewControllerOutput {
 }
 
-extension CreateOrderPresenter: CreateOrderInteractorOutput
-{
+extension CreateOrderPresenter: CreateOrderInteractorOutput {
 }
 
-class CreateOrderConfigurator
-{
+class CreateOrderConfigurator {
   // MARK: Object lifecycle
   
-  class var sharedInstance: CreateOrderConfigurator
-  {
+  class var sharedInstance: CreateOrderConfigurator {
     struct Static {
       static var instance: CreateOrderConfigurator?
       static var token: dispatch_once_t = 0
@@ -49,8 +43,7 @@ class CreateOrderConfigurator
   
   // MARK: Configuration
   
-  func configure(viewController: CreateOrderViewController)
-  {
+  func configure(viewController: CreateOrderViewController) {
     let router = CreateOrderRouter()
     router.viewController = viewController
     

--- a/CleanStore/Scenes/CreateOrder/CreateOrderInteractor.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderInteractor.swift
@@ -11,19 +11,16 @@
 
 import UIKit
 
-protocol CreateOrderInteractorInput
-{
+protocol CreateOrderInteractorInput {
   var shippingMethods: [String] { get }
   func formatExpirationDate(request: CreateOrder_FormatExpirationDate_Request)
 }
 
-protocol CreateOrderInteractorOutput
-{
+protocol CreateOrderInteractorOutput {
   func presentExpirationDate(response: CreateOrder_FormatExpirationDate_Response)
 }
 
-class CreateOrderInteractor: CreateOrderInteractorInput
-{
+class CreateOrderInteractor: CreateOrderInteractorInput {
   var output: CreateOrderInteractorOutput!
   var worker: CreateOrderWorker!
   var shippingMethods = [
@@ -34,8 +31,7 @@ class CreateOrderInteractor: CreateOrderInteractorInput
   
   // MARK: Expiration date
   
-  func formatExpirationDate(request: CreateOrder_FormatExpirationDate_Request)
-  {
+  func formatExpirationDate(request: CreateOrder_FormatExpirationDate_Request) {
     let response = CreateOrder_FormatExpirationDate_Response(date: request.date)
     output.presentExpirationDate(response)
   }

--- a/CleanStore/Scenes/CreateOrder/CreateOrderModels.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderModels.swift
@@ -11,17 +11,14 @@
 
 import UIKit
 
-struct CreateOrder_FormatExpirationDate_Request
-{
+struct CreateOrder_FormatExpirationDate_Request {
   var date: NSDate
 }
 
-struct CreateOrder_FormatExpirationDate_Response
-{
+struct CreateOrder_FormatExpirationDate_Response {
   var date: NSDate
 }
 
-struct CreateOrder_FormatExpirationDate_ViewModel
-{
+struct CreateOrder_FormatExpirationDate_ViewModel {
   var date: String
 }

--- a/CleanStore/Scenes/CreateOrder/CreateOrderPresenter.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderPresenter.swift
@@ -11,19 +11,17 @@
 
 import UIKit
 
-protocol CreateOrderPresenterInput
-{
+protocol CreateOrderPresenterInput {
   func presentExpirationDate(response: CreateOrder_FormatExpirationDate_Response)
 }
 
-protocol CreateOrderPresenterOutput: class
-{
+protocol CreateOrderPresenterOutput: class {
   func displayExpirationDate(viewModel: CreateOrder_FormatExpirationDate_ViewModel)
 }
 
-class CreateOrderPresenter: CreateOrderPresenterInput
-{
+class CreateOrderPresenter: CreateOrderPresenterInput {
   weak var output: CreateOrderPresenterOutput!
+  
   let dateFormatter: NSDateFormatter = {
     let dateFormatter = NSDateFormatter()
     dateFormatter.dateStyle = .ShortStyle
@@ -33,8 +31,7 @@ class CreateOrderPresenter: CreateOrderPresenterInput
   
   // MARK: Expiration date
   
-  func presentExpirationDate(response: CreateOrder_FormatExpirationDate_Response)
-  {
+  func presentExpirationDate(response: CreateOrder_FormatExpirationDate_Response) {
     let date = dateFormatter.stringFromDate(response.date)
     let viewModel = CreateOrder_FormatExpirationDate_ViewModel(date: date)
     output.displayExpirationDate(viewModel)

--- a/CleanStore/Scenes/CreateOrder/CreateOrderRouter.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderRouter.swift
@@ -11,19 +11,16 @@
 
 import UIKit
 
-protocol CreateOrderRouterInput
-{
+protocol CreateOrderRouterInput {
   func navigateToSomewhere()
 }
 
-class CreateOrderRouter
-{
+class CreateOrderRouter {
   weak var viewController: CreateOrderViewController!
   
   // MARK: Navigation
   
-  func navigateToSomewhere()
-  {
+  func navigateToSomewhere() {
     // NOTE: Teach the router how to navigate to another scene. Some examples follow:
     
     // 1. Trigger a storyboard segue
@@ -43,8 +40,7 @@ class CreateOrderRouter
   
   // MARK: Communication
   
-  func passDataToNextScene(segue: UIStoryboardSegue)
-  {
+  func passDataToNextScene(segue: UIStoryboardSegue) {
     // NOTE: Teach the router which scenes it can communicate with
     
     if segue.identifier == "ShowSomewhereScene" {
@@ -52,8 +48,7 @@ class CreateOrderRouter
     }
   }
   
-  func passDataToSomewhereScene(segue: UIStoryboardSegue)
-  {
+  func passDataToSomewhereScene(segue: UIStoryboardSegue) {
     // NOTE: Teach the router how to pass data to the next scene
     
     // let someWhereViewController = segue.destinationViewController as! SomeWhereViewController

--- a/CleanStore/Scenes/CreateOrder/CreateOrderViewController.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderViewController.swift
@@ -20,7 +20,7 @@ protocol CreateOrderViewControllerOutput {
   func formatExpirationDate(request: CreateOrder_FormatExpirationDate_Request)
 }
 
-class CreateOrderViewController: UITableViewController, CreateOrderViewControllerInput, UITextFieldDelegate, UIPickerViewDataSource, UIPickerViewDelegate {
+class CreateOrderViewController: UITableViewController, CreateOrderViewControllerInput {
   var output: CreateOrderViewControllerOutput!
   var router: CreateOrderRouter!
   
@@ -40,32 +40,9 @@ class CreateOrderViewController: UITableViewController, CreateOrderViewControlle
     configurePickers()
   }
   
-  // MARK: Text fields
+  // MARK: Text Fields
   
   @IBOutlet var textFields: [UITextField]!
-  
-  func textFieldShouldReturn(textField: UITextField) -> Bool
-  {
-    textField.resignFirstResponder()
-    if let index = textFields.indexOf(textField) {
-      if index < textFields.count - 1 {
-        let nextTextField = textFields[index + 1]
-        nextTextField.becomeFirstResponder()
-      }
-    }
-    return true
-  }
-  
-  override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath)
-  {
-    if let cell = tableView.cellForRowAtIndexPath(indexPath) {
-      for textField in textFields {
-        if textField.isDescendantOfView(cell) {
-          textField.becomeFirstResponder()
-        }
-      }
-    }
-  }
   
   // MARK: Shipping method
   
@@ -77,21 +54,6 @@ class CreateOrderViewController: UITableViewController, CreateOrderViewControlle
     expirationDateTextField.inputView = expirationDatePicker
   }
   
-  func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
-    return 1
-  }
-  
-  func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-    return output.shippingMethods.count
-  }
-  
-  func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-    return output.shippingMethods[row]
-  }
-  
-  func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-    shippingMethodTextField.text = output.shippingMethods[row]
-  }
   
   // MARK: Expiration date
   

--- a/CleanStore/Scenes/CreateOrder/CreateOrderViewController.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderViewController.swift
@@ -11,19 +11,16 @@
 
 import UIKit
 
-protocol CreateOrderViewControllerInput
-{
+protocol CreateOrderViewControllerInput {
   func displayExpirationDate(viewModel: CreateOrder_FormatExpirationDate_ViewModel)
 }
 
-protocol CreateOrderViewControllerOutput
-{
+protocol CreateOrderViewControllerOutput {
   var shippingMethods: [String] { get }
   func formatExpirationDate(request: CreateOrder_FormatExpirationDate_Request)
 }
 
-class CreateOrderViewController: UITableViewController, CreateOrderViewControllerInput, UITextFieldDelegate, UIPickerViewDataSource, UIPickerViewDelegate
-{
+class CreateOrderViewController: UITableViewController, CreateOrderViewControllerInput, UITextFieldDelegate, UIPickerViewDataSource, UIPickerViewDelegate {
   var output: CreateOrderViewControllerOutput!
   var router: CreateOrderRouter!
   
@@ -75,29 +72,24 @@ class CreateOrderViewController: UITableViewController, CreateOrderViewControlle
   @IBOutlet weak var shippingMethodTextField: UITextField!
   @IBOutlet var shippingMethodPicker: UIPickerView!
   
-  func configurePickers()
-  {
+  func configurePickers() {
     shippingMethodTextField.inputView = shippingMethodPicker
     expirationDateTextField.inputView = expirationDatePicker
   }
   
-  func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int
-  {
+  func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
     return 1
   }
   
-  func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int
-  {
+  func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
     return output.shippingMethods.count
   }
   
-  func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String?
-  {
+  func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
     return output.shippingMethods[row]
   }
   
-  func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int)
-  {
+  func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
     shippingMethodTextField.text = output.shippingMethods[row]
   }
   
@@ -106,15 +98,13 @@ class CreateOrderViewController: UITableViewController, CreateOrderViewControlle
   @IBOutlet weak var expirationDateTextField: UITextField!
   @IBOutlet var expirationDatePicker: UIDatePicker!
   
-  @IBAction func expirationDatePickerValueChanged(sender: AnyObject)
-  {
+  @IBAction func expirationDatePickerValueChanged(sender: AnyObject) {
     let date = expirationDatePicker.date
     let request = CreateOrder_FormatExpirationDate_Request(date: date)
     output.formatExpirationDate(request)
   }
   
-  func displayExpirationDate(viewModel: CreateOrder_FormatExpirationDate_ViewModel)
-  {
+  func displayExpirationDate(viewModel: CreateOrder_FormatExpirationDate_ViewModel) {
     let date = viewModel.date
     expirationDateTextField.text = date
   }

--- a/CleanStore/Scenes/CreateOrder/CreateOrderViewControllerPickerView.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderViewControllerPickerView.swift
@@ -1,0 +1,37 @@
+//
+//  CreateOrderViewControllerPickerView.swift
+//  CleanStore
+//
+//  Created by Mati on 22/1/16.
+//  Copyright © 2016 Raymond Law. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension CreateOrderViewController: UIPickerViewDataSource {
+  
+  // MARK: - PickerView Data Source
+  
+  func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
+    return 1
+  }
+  
+  func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    return output.shippingMethods.count
+  }
+  
+  func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+    return output.shippingMethods[row]
+  }
+  
+  func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+    shippingMethodTextField.text = output.shippingMethods[row]
+  }
+}
+
+extension CreateOrderViewController: UIPickerViewDelegate {
+  
+  // MARK: - PickerView Delegate
+  
+}

--- a/CleanStore/Scenes/CreateOrder/CreateOrderViewControllerTextField.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderViewControllerTextField.swift
@@ -1,0 +1,41 @@
+//
+//  CreateOrderViewControllerTextField.swift
+//  CleanStore
+//
+//  Created by Mati on 22/1/16.
+//  Copyright © 2016 Raymond Law. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+
+extension CreateOrderViewController: UITextFieldDelegate {
+  
+  // MARK: Text fields
+  
+  
+  func textFieldShouldReturn(textField: UITextField) -> Bool
+  {
+    textField.resignFirstResponder()
+    if let index = textFields.indexOf(textField) {
+      if index < textFields.count - 1 {
+        let nextTextField = textFields[index + 1]
+        nextTextField.becomeFirstResponder()
+      }
+    }
+    return true
+  }
+  
+  override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath)
+  {
+    if let cell = tableView.cellForRowAtIndexPath(indexPath) {
+      for textField in textFields {
+        if textField.isDescendantOfView(cell) {
+          textField.becomeFirstResponder()
+        }
+      }
+    }
+  }
+  
+}

--- a/CleanStore/Scenes/CreateOrder/CreateOrderWorker.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderWorker.swift
@@ -11,12 +11,10 @@
 
 import UIKit
 
-class CreateOrderWorker
-{
+class CreateOrderWorker {
   // MARK: Business Logic
   
-  func doSomeWork()
-  {
+  func doSomeWork() {
     // NOTE: Do the work
   }
 }

--- a/CleanStore/Scenes/ListOrders/ListOrdersConfigurator.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersConfigurator.swift
@@ -13,28 +13,22 @@ import UIKit
 
 // MARK: Connect View, Interactor, and Presenter
 
-extension ListOrdersViewController: ListOrdersPresenterOutput
-{
-  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?)
-  {
+extension ListOrdersViewController: ListOrdersPresenterOutput {
+  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
     router.passDataToNextScene(segue)
   }
 }
 
-extension ListOrdersInteractor: ListOrdersViewControllerOutput
-{
+extension ListOrdersInteractor: ListOrdersViewControllerOutput {
 }
 
-extension ListOrdersPresenter: ListOrdersInteractorOutput
-{
+extension ListOrdersPresenter: ListOrdersInteractorOutput {
 }
 
-class ListOrdersConfigurator
-{
+class ListOrdersConfigurator {
   // MARK: Object lifecycle
   
-  class var sharedInstance: ListOrdersConfigurator
-  {
+  class var sharedInstance: ListOrdersConfigurator {
     struct Static {
       static var instance: ListOrdersConfigurator?
       static var token: dispatch_once_t = 0
@@ -49,8 +43,7 @@ class ListOrdersConfigurator
   
   // MARK: Configuration
   
-  func configure(viewController: ListOrdersViewController)
-  {
+  func configure(viewController: ListOrdersViewController) {
     let router = ListOrdersRouter()
     router.viewController = viewController
     

--- a/CleanStore/Scenes/ListOrders/ListOrdersInteractor.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersInteractor.swift
@@ -11,25 +11,21 @@
 
 import UIKit
 
-protocol ListOrdersInteractorInput
-{
+protocol ListOrdersInteractorInput {
   func fetchOrders(request: ListOrders_FetchOrders_Request)
 }
 
-protocol ListOrdersInteractorOutput
-{
+protocol ListOrdersInteractorOutput {
   func presentFetchedOrders(response: ListOrders_FetchOrders_Response)
 }
 
-class ListOrdersInteractor: ListOrdersInteractorInput
-{
+class ListOrdersInteractor: ListOrdersInteractorInput {
   var output: ListOrdersInteractorOutput!
   var ordersWorker = OrdersWorker(ordersStore: OrdersMemStore())
   
   // MARK: Business logic
   
-  func fetchOrders(request: ListOrders_FetchOrders_Request)
-  {
+  func fetchOrders(request: ListOrders_FetchOrders_Request) {
     ordersWorker.fetchOrders { (orders) -> Void in
       let response = ListOrders_FetchOrders_Response(orders: orders)
       self.output.presentFetchedOrders(response)

--- a/CleanStore/Scenes/ListOrders/ListOrdersModels.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersModels.swift
@@ -11,19 +11,15 @@
 
 import UIKit
 
-struct ListOrders_FetchOrders_Request
-{
+struct ListOrders_FetchOrders_Request {
 }
 
-struct ListOrders_FetchOrders_Response
-{
+struct ListOrders_FetchOrders_Response {
   var orders: [Order]
 }
 
-struct ListOrders_FetchOrders_ViewModel
-{
-  struct DisplayedOrder
-  {
+struct ListOrders_FetchOrders_ViewModel {
+  struct DisplayedOrder {
     var id: String
     var date: String
     var email: String

--- a/CleanStore/Scenes/ListOrders/ListOrdersPresenter.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersPresenter.swift
@@ -11,25 +11,24 @@
 
 import UIKit
 
-protocol ListOrdersPresenterInput
-{
+protocol ListOrdersPresenterInput {
   func presentFetchedOrders(response: ListOrders_FetchOrders_Response)
 }
 
-protocol ListOrdersPresenterOutput: class
-{
+protocol ListOrdersPresenterOutput: class {
   func displayFetchedOrders(viewModel: ListOrders_FetchOrders_ViewModel)
 }
 
-class ListOrdersPresenter: ListOrdersPresenterInput
-{
+class ListOrdersPresenter: ListOrdersPresenterInput {
   weak var output: ListOrdersPresenterOutput!
+  
   let dateFormatter: NSDateFormatter = {
     let dateFormatter = NSDateFormatter()
     dateFormatter.dateStyle = .ShortStyle
     dateFormatter.timeStyle = NSDateFormatterStyle.NoStyle
     return dateFormatter
   }()
+  
   let currencyFormatter: NSNumberFormatter = {
     let currencyFormatter = NSNumberFormatter()
     currencyFormatter.numberStyle = .CurrencyStyle
@@ -38,8 +37,7 @@ class ListOrdersPresenter: ListOrdersPresenterInput
   
   // MARK: Presentation logic
   
-  func presentFetchedOrders(response: ListOrders_FetchOrders_Response)
-  {
+  func presentFetchedOrders(response: ListOrders_FetchOrders_Response) {
     var displayedOrders: [ListOrders_FetchOrders_ViewModel.DisplayedOrder] = []
     for order in response.orders {
       let date = dateFormatter.stringFromDate(order.date!)

--- a/CleanStore/Scenes/ListOrders/ListOrdersRouter.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersRouter.swift
@@ -11,19 +11,16 @@
 
 import UIKit
 
-protocol ListOrdersRouterInput
-{
+protocol ListOrdersRouterInput {
   func navigateToSomewhere()
 }
 
-class ListOrdersRouter
-{
+class ListOrdersRouter {
   weak var viewController: ListOrdersViewController!
   
   // MARK: Navigation
   
-  func navigateToSomewhere()
-  {
+  func navigateToSomewhere() {
     // NOTE: Teach the router how to navigate to another scene. Some examples follow:
     
     // 1. Trigger a storyboard segue
@@ -43,8 +40,7 @@ class ListOrdersRouter
   
   // MARK: Communication
   
-  func passDataToNextScene(segue: UIStoryboardSegue)
-  {
+  func passDataToNextScene(segue: UIStoryboardSegue) {
     // NOTE: Teach the router which scenes it can communicate with
     
     if segue.identifier == "ShowSomewhereScene" {
@@ -52,8 +48,7 @@ class ListOrdersRouter
     }
   }
   
-  func passDataToSomewhereScene(segue: UIStoryboardSegue)
-  {
+  func passDataToSomewhereScene(segue: UIStoryboardSegue) {
     // NOTE: Teach the router how to pass data to the next scene
     
     // let someWhereViewController = segue.destinationViewController as! SomeWhereViewController

--- a/CleanStore/Scenes/ListOrders/ListOrdersViewController.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersViewController.swift
@@ -11,52 +11,44 @@
 
 import UIKit
 
-protocol ListOrdersViewControllerInput
-{
+protocol ListOrdersViewControllerInput {
   func displayFetchedOrders(viewModel: ListOrders_FetchOrders_ViewModel)
 }
 
-protocol ListOrdersViewControllerOutput
-{
+protocol ListOrdersViewControllerOutput {
   func fetchOrders(request: ListOrders_FetchOrders_Request)
 }
 
-class ListOrdersViewController: UITableViewController, ListOrdersViewControllerInput
-{
+class ListOrdersViewController: UITableViewController, ListOrdersViewControllerInput {
   var output: ListOrdersViewControllerOutput!
   var router: ListOrdersRouter!
   var displayedOrders: [ListOrders_FetchOrders_ViewModel.DisplayedOrder] = []
   
   // MARK: Object lifecycle
   
-  override func awakeFromNib()
-  {
+  override func awakeFromNib() {
     super.awakeFromNib()
     ListOrdersConfigurator.sharedInstance.configure(self)
   }
   
   // MARK: View lifecycle
   
-  override func viewDidLoad()
-  {
+  override func viewDidLoad() {
     super.viewDidLoad()
     fetchOrdersOnLoad()
   }
   
   // MARK: Event handling
   
-  func fetchOrdersOnLoad()
-  {
+  func fetchOrdersOnLoad() {
     let request = ListOrders_FetchOrders_Request()
     output.fetchOrders(request)
   }
   
   // MARK: Display logic
   
-  func displayFetchedOrders(viewModel: ListOrders_FetchOrders_ViewModel)
-  {
+  func displayFetchedOrders(viewModel: ListOrders_FetchOrders_ViewModel) {
     displayedOrders = viewModel.displayedOrders
     tableView.reloadData()
   }
-  
 }

--- a/CleanStore/Scenes/ListOrders/ListOrdersViewController.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersViewController.swift
@@ -59,27 +59,4 @@ class ListOrdersViewController: UITableViewController, ListOrdersViewControllerI
     tableView.reloadData()
   }
   
-  // MARK: Table view data source
-  
-  override func numberOfSectionsInTableView(tableView: UITableView) -> Int
-  {
-    return 1
-  }
-  
-  override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int
-  {
-    return displayedOrders.count
-  }
-  
-  override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell
-  {
-    let displayedOrder = displayedOrders[indexPath.row]
-    var cell = tableView.dequeueReusableCellWithIdentifier("OrderTableViewCell")
-    if cell == nil {
-      cell = UITableViewCell(style: .Value1, reuseIdentifier: "OrderTableViewCell")
-    }
-    cell?.textLabel?.text = displayedOrder.date
-    cell?.detailTextLabel?.text = displayedOrder.total
-    return cell!
-  }
 }

--- a/CleanStore/Scenes/ListOrders/ListOrdersViewControllerTableView.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersViewControllerTableView.swift
@@ -12,18 +12,15 @@ extension ListOrdersViewController {
   
   // MARK: Table view data source
   
-  override func numberOfSectionsInTableView(tableView: UITableView) -> Int
-  {
+  override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
     return 1
   }
   
-  override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int
-  {
+  override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return displayedOrders.count
   }
   
-  override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell
-  {
+  override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
     var cell = tableView.dequeueReusableCellWithIdentifier("OrderTableViewCell")
     if cell == nil {
       cell = UITableViewCell(style: .Value1, reuseIdentifier: "OrderTableViewCell")

--- a/CleanStore/Scenes/ListOrders/ListOrdersViewControllerTableView.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersViewControllerTableView.swift
@@ -1,0 +1,36 @@
+//
+//  ListOrdersViewControllerTableView.swift
+//  CleanStore
+//
+//  Created by Mati on 22/1/16.
+//  Copyright © 2016 Raymond Law. All rights reserved.
+//
+
+import UIKit
+
+extension ListOrdersViewController {
+  
+  // MARK: Table view data source
+  
+  override func numberOfSectionsInTableView(tableView: UITableView) -> Int
+  {
+    return 1
+  }
+  
+  override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int
+  {
+    return displayedOrders.count
+  }
+  
+  override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell
+  {
+    var cell = tableView.dequeueReusableCellWithIdentifier("OrderTableViewCell")
+    if cell == nil {
+      cell = UITableViewCell(style: .Value1, reuseIdentifier: "OrderTableViewCell")
+    }
+    let displayedOrder = displayedOrders[indexPath.row]
+    cell?.textLabel?.text = displayedOrder.date
+    cell?.detailTextLabel?.text = displayedOrder.total
+    return cell!
+  }
+}

--- a/CleanStore/Scenes/ListOrders/ListOrdersWorker.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersWorker.swift
@@ -11,8 +11,7 @@
 
 import UIKit
 
-class ListOrdersWorker
-{
+class ListOrdersWorker {
   // MARK: Business Logic
   
   func doSomeWork()

--- a/CleanStore/Services/OrdersAPI.swift
+++ b/CleanStore/Services/OrdersAPI.swift
@@ -1,70 +1,54 @@
 import Foundation
 
-class OrdersAPI: OrdersStoreProtocol
-{
+class OrdersAPI: OrdersStoreProtocol {
   // MARK: - CRUD operations - Optional error
   
-  func fetchOrders(completionHandler: (orders: [Order], error: OrdersStoreError?) -> Void)
-  {
+  func fetchOrders(completionHandler: (orders: [Order], error: OrdersStoreError?) -> Void) {
   }
   
-  func fetchOrder(id: String, completionHandler: (order: Order?, error: OrdersStoreError?) -> Void)
-  {
+  func fetchOrder(id: String, completionHandler: (order: Order?, error: OrdersStoreError?) -> Void) {
   }
   
-  func createOrder(orderToCreate: Order, completionHandler: (error: OrdersStoreError?) -> Void)
-  {
+  func createOrder(orderToCreate: Order, completionHandler: (error: OrdersStoreError?) -> Void) {
   }
   
-  func updateOrder(orderToUpdate: Order, completionHandler: (error: OrdersStoreError?) -> Void)
-  {
+  func updateOrder(orderToUpdate: Order, completionHandler: (error: OrdersStoreError?) -> Void) {
   }
   
-  func deleteOrder(id: String, completionHandler: (error: OrdersStoreError?) -> Void)
-  {
+  func deleteOrder(id: String, completionHandler: (error: OrdersStoreError?) -> Void) {
   }
   
   // MARK: - CRUD operations - Generic enum result type
   
-  func fetchOrders(completionHandler: OrdersStoreFetchOrdersCompletionHandler)
-  {
+  func fetchOrders(completionHandler: OrdersStoreFetchOrdersCompletionHandler) {
   }
   
-  func fetchOrder(id: String, completionHandler: OrdersStoreFetchOrderCompletionHandler)
-  {
+  func fetchOrder(id: String, completionHandler: OrdersStoreFetchOrderCompletionHandler) {
   }
   
-  func createOrder(orderToCreate: Order, completionHandler: OrdersStoreCreateOrderCompletionHandler)
-  {
+  func createOrder(orderToCreate: Order, completionHandler: OrdersStoreCreateOrderCompletionHandler) {
   }
   
-  func updateOrder(orderToUpdate: Order, completionHandler: OrdersStoreUpdateOrderCompletionHandler)
-  {
+  func updateOrder(orderToUpdate: Order, completionHandler: OrdersStoreUpdateOrderCompletionHandler) {
   }
   
-  func deleteOrder(id: String, completionHandler: OrdersStoreDeleteOrderCompletionHandler)
-  {
+  func deleteOrder(id: String, completionHandler: OrdersStoreDeleteOrderCompletionHandler) {
   }
   
   // MARK: - CRUD operations - Inner closure
   
-  func fetchOrders(completionHandler: (orders: () throws -> [Order]) -> Void)
-  {
+  func fetchOrders(completionHandler: (orders: () throws -> [Order]) -> Void) {
   }
   
-  func fetchOrder(id: String, completionHandler: (order: () throws -> Order?) -> Void)
-  {
+  func fetchOrder(id: String, completionHandler: (order: () throws -> Order?) -> Void) {
   }
   
-  func createOrder(orderToCreate: Order, completionHandler: (done: () throws -> Void) -> Void)
-  {
+  func createOrder(orderToCreate: Order, completionHandler: (done: () throws -> Void) -> Void) {
   }
   
-  func updateOrder(orderToUpdate: Order, completionHandler: (done: () throws -> Void) -> Void)
-  {
+  func updateOrder(orderToUpdate: Order, completionHandler: (done: () throws -> Void) -> Void) {
   }
   
-  func deleteOrder(id: String, completionHandler: (done: () throws -> Void) -> Void)
-  {
+  func deleteOrder(id: String, completionHandler: (done: () throws -> Void) -> Void) {
   }
 }

--- a/CleanStore/Services/OrdersCoreDataStore.swift
+++ b/CleanStore/Services/OrdersCoreDataStore.swift
@@ -1,7 +1,6 @@
 import CoreData
 
-class OrdersCoreDataStore: OrdersStoreProtocol
-{
+class OrdersCoreDataStore: OrdersStoreProtocol {
   // MARK: - Managed object contexts
   
   var mainManagedObjectContext: NSManagedObjectContext
@@ -9,8 +8,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
   
   // MARK: - Object lifecycle
   
-  init()
-  {
+  init() {
     // This resource is the same name as your xcdatamodeld contained in your project.
     guard let modelURL = NSBundle.mainBundle().URLForResource("CleanStore", withExtension:"momd") else {
       fatalError("Error loading model from bundle")
@@ -41,8 +39,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     privateManagedObjectContext.parentContext = mainManagedObjectContext
   }
   
-  deinit
-  {
+  deinit {
     do {
       try self.mainManagedObjectContext.save()
     } catch {
@@ -52,8 +49,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
   
   // MARK: - CRUD operations - Optional error
   
-  func fetchOrders(completionHandler: (orders: [Order], error: OrdersStoreError?) -> Void)
-  {
+  func fetchOrders(completionHandler: (orders: [Order], error: OrdersStoreError?) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -66,8 +62,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func fetchOrder(id: String, completionHandler: (order: Order?, error: OrdersStoreError?) -> Void)
-  {
+  func fetchOrder(id: String, completionHandler: (order: Order?, error: OrdersStoreError?) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -84,8 +79,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func createOrder(orderToCreate: Order, completionHandler: (error: OrdersStoreError?) -> Void)
-  {
+  func createOrder(orderToCreate: Order, completionHandler: (error: OrdersStoreError?) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let managedOrder = NSEntityDescription.insertNewObjectForEntityForName("ManagedOrder", inManagedObjectContext: self.privateManagedObjectContext) as! ManagedOrder
@@ -103,8 +97,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func updateOrder(orderToUpdate: Order, completionHandler: (error: OrdersStoreError?) -> Void)
-  {
+  func updateOrder(orderToUpdate: Order, completionHandler: (error: OrdersStoreError?) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -130,8 +123,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func deleteOrder(id: String, completionHandler: (error: OrdersStoreError?) -> Void)
-  {
+  func deleteOrder(id: String, completionHandler: (error: OrdersStoreError?) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -156,8 +148,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
   
   // MARK: - CRUD operations - Generic enum result type
   
-  func fetchOrders(completionHandler: OrdersStoreFetchOrdersCompletionHandler)
-  {
+  func fetchOrders(completionHandler: OrdersStoreFetchOrdersCompletionHandler) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -170,8 +161,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func fetchOrder(id: String, completionHandler: OrdersStoreFetchOrderCompletionHandler)
-  {
+  func fetchOrder(id: String, completionHandler: OrdersStoreFetchOrderCompletionHandler) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -188,8 +178,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func createOrder(orderToCreate: Order, completionHandler: OrdersStoreCreateOrderCompletionHandler)
-  {
+  func createOrder(orderToCreate: Order, completionHandler: OrdersStoreCreateOrderCompletionHandler) {
     privateManagedObjectContext.performBlock {
       do {
         let managedOrder = NSEntityDescription.insertNewObjectForEntityForName("ManagedOrder", inManagedObjectContext: self.privateManagedObjectContext) as! ManagedOrder
@@ -208,8 +197,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func updateOrder(orderToUpdate: Order, completionHandler: OrdersStoreUpdateOrderCompletionHandler)
-  {
+  func updateOrder(orderToUpdate: Order, completionHandler: OrdersStoreUpdateOrderCompletionHandler) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -235,8 +223,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func deleteOrder(id: String, completionHandler: OrdersStoreDeleteOrderCompletionHandler)
-  {
+  func deleteOrder(id: String, completionHandler: OrdersStoreDeleteOrderCompletionHandler) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -261,8 +248,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
   
   // MARK: - CRUD operations - Inner closure
   
-  func fetchOrders(completionHandler: (orders: () throws -> [Order]) -> Void)
-  {
+  func fetchOrders(completionHandler: (orders: () throws -> [Order]) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -275,8 +261,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func fetchOrder(id: String, completionHandler: (order: () throws -> Order?) -> Void)
-  {
+  func fetchOrder(id: String, completionHandler: (order: () throws -> Order?) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -293,8 +278,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func createOrder(orderToCreate: Order, completionHandler: (done: () throws -> Void) -> Void)
-  {
+  func createOrder(orderToCreate: Order, completionHandler: (done: () throws -> Void) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let managedOrder = NSEntityDescription.insertNewObjectForEntityForName("ManagedOrder", inManagedObjectContext: self.privateManagedObjectContext) as! ManagedOrder
@@ -312,8 +296,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func updateOrder(orderToUpdate: Order, completionHandler: (done: () throws -> Void) -> Void)
-  {
+  func updateOrder(orderToUpdate: Order, completionHandler: (done: () throws -> Void) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")
@@ -339,8 +322,7 @@ class OrdersCoreDataStore: OrdersStoreProtocol
     }
   }
   
-  func deleteOrder(id: String, completionHandler: (done: () throws -> Void) -> Void)
-  {
+  func deleteOrder(id: String, completionHandler: (done: () throws -> Void) -> Void) {
     privateManagedObjectContext.performBlock {
       do {
         let fetchRequest = NSFetchRequest(entityName: "ManagedOrder")

--- a/CleanStore/Services/OrdersMemStore.swift
+++ b/CleanStore/Services/OrdersMemStore.swift
@@ -1,23 +1,20 @@
 import Foundation
 
-class OrdersMemStore: OrdersStoreProtocol
-{
+class OrdersMemStore: OrdersStoreProtocol {
   // MARK: - Data
   
   var orders = [Order]()
   
   // MARK: - CRUD operations - Optional error
   
-  func fetchOrders(completionHandler: (orders: [Order], error: OrdersStoreError?) -> Void)
-  {
+  func fetchOrders(completionHandler: (orders: [Order], error: OrdersStoreError?) -> Void) {
     completionHandler(orders: orders, error: nil)
   }
   
-  func fetchOrder(id: String, completionHandler: (order: Order?, error: OrdersStoreError?) -> Void)
-  {
+  func fetchOrder(id: String, completionHandler: (order: Order?, error: OrdersStoreError?) -> Void) {
     let order = orders.filter { (order: Order) -> Bool in
       return order.id == id
-    }.first
+      }.first
     if let _ = order {
       completionHandler(order: order, error: nil)
     } else {
@@ -25,14 +22,12 @@ class OrdersMemStore: OrdersStoreProtocol
     }
   }
   
-  func createOrder(order: Order, completionHandler: (error: OrdersStoreError?) -> Void)
-  {
+  func createOrder(order: Order, completionHandler: (error: OrdersStoreError?) -> Void) {
     orders.append(order)
     completionHandler(error: nil)
   }
   
-  func updateOrder(orderToUpdate: Order, completionHandler: (error: OrdersStoreError?) -> Void)
-  {
+  func updateOrder(orderToUpdate: Order, completionHandler: (error: OrdersStoreError?) -> Void) {
     for var order in orders {
       if order.id == orderToUpdate.id {
         order = orderToUpdate
@@ -43,8 +38,7 @@ class OrdersMemStore: OrdersStoreProtocol
     completionHandler(error: OrdersStoreError.CannotUpdate("Cannot fetch order with id \(orderToUpdate.id) to update"))
   }
   
-  func deleteOrder(id: String, completionHandler: (error: OrdersStoreError?) -> Void)
-  {
+  func deleteOrder(id: String, completionHandler: (error: OrdersStoreError?) -> Void) {
     let index = orders.indexOf { (order: Order) -> Bool in
       return order.id == id
     }
@@ -58,13 +52,11 @@ class OrdersMemStore: OrdersStoreProtocol
   
   // MARK: - CRUD operations - Generic enum result type
   
-  func fetchOrders(completionHandler: OrdersStoreFetchOrdersCompletionHandler)
-  {
+  func fetchOrders(completionHandler: OrdersStoreFetchOrdersCompletionHandler) {
     completionHandler(result: OrdersStoreResult.Success(result: orders))
   }
   
-  func fetchOrder(id: String, completionHandler: OrdersStoreFetchOrderCompletionHandler)
-  {
+  func fetchOrder(id: String, completionHandler: OrdersStoreFetchOrderCompletionHandler) {
     let order = orders.filter { (order: Order) -> Bool in
       return order.id == id
       }.first
@@ -75,14 +67,12 @@ class OrdersMemStore: OrdersStoreProtocol
     }
   }
   
-  func createOrder(order: Order, completionHandler: OrdersStoreCreateOrderCompletionHandler)
-  {
+  func createOrder(order: Order, completionHandler: OrdersStoreCreateOrderCompletionHandler) {
     orders.append(order)
     completionHandler(result: OrdersStoreResult.Success(result: ()))
   }
   
-  func updateOrder(orderToUpdate: Order, completionHandler: OrdersStoreUpdateOrderCompletionHandler)
-  {
+  func updateOrder(orderToUpdate: Order, completionHandler: OrdersStoreUpdateOrderCompletionHandler) {
     for var order in orders {
       if order.id == orderToUpdate.id {
         order = orderToUpdate
@@ -93,8 +83,7 @@ class OrdersMemStore: OrdersStoreProtocol
     completionHandler(result: OrdersStoreResult.Failure(error: OrdersStoreError.CannotUpdate("Cannot update order with id \(orderToUpdate.id) to update")))
   }
   
-  func deleteOrder(id: String, completionHandler: OrdersStoreDeleteOrderCompletionHandler)
-  {
+  func deleteOrder(id: String, completionHandler: OrdersStoreDeleteOrderCompletionHandler) {
     let index = orders.indexOf { (order: Order) -> Bool in
       return order.id == id
     }
@@ -108,13 +97,11 @@ class OrdersMemStore: OrdersStoreProtocol
   
   // MARK: - CRUD operations - Inner closure
   
-  func fetchOrders(completionHandler: (orders: () throws -> [Order]) -> Void)
-  {
+  func fetchOrders(completionHandler: (orders: () throws -> [Order]) -> Void) {
     completionHandler { return self.orders }
   }
   
-  func fetchOrder(id: String, completionHandler: (order: () throws -> Order?) -> Void)
-  {
+  func fetchOrder(id: String, completionHandler: (order: () throws -> Order?) -> Void) {
     let index = orders.indexOf { (order: Order) -> Bool in
       return order.id == id
     }
@@ -125,14 +112,12 @@ class OrdersMemStore: OrdersStoreProtocol
     }
   }
   
-  func createOrder(order: Order, completionHandler: (done: () throws -> Void) -> Void)
-  {
+  func createOrder(order: Order, completionHandler: (done: () throws -> Void) -> Void) {
     orders.append(order)
     completionHandler { return }
   }
   
-  func updateOrder(orderToUpdate: Order, completionHandler: (done: () throws -> Void) -> Void)
-  {
+  func updateOrder(orderToUpdate: Order, completionHandler: (done: () throws -> Void) -> Void) {
     let index = orders.indexOf { (order: Order) -> Bool in
       return order.id == orderToUpdate.id
     }
@@ -144,8 +129,7 @@ class OrdersMemStore: OrdersStoreProtocol
     }
   }
   
-  func deleteOrder(id: String, completionHandler: (done: () throws -> Void) -> Void)
-  {
+  func deleteOrder(id: String, completionHandler: (done: () throws -> Void) -> Void) {
     let index = orders.indexOf { (order: Order) -> Bool in
       return order.id == id
     }

--- a/CleanStore/Workers/OrdersWorker.swift
+++ b/CleanStore/Workers/OrdersWorker.swift
@@ -2,17 +2,14 @@ import Foundation
 
 // MARK: - Orders worker
 
-class OrdersWorker
-{
+class OrdersWorker {
   var ordersStore: OrdersStoreProtocol
   
-  init(ordersStore: OrdersStoreProtocol)
-  {
+  init(ordersStore: OrdersStoreProtocol) {
     self.ordersStore = ordersStore
   }
   
-  func fetchOrders(completionHandler: (orders: [Order]) -> Void)
-  {
+  func fetchOrders(completionHandler: (orders: [Order]) -> Void) {
     ordersStore.fetchOrders { (orders: () throws -> [Order]) -> Void in
       do {
         let orders = try orders()
@@ -26,8 +23,7 @@ class OrdersWorker
 
 // MARK: - Orders store API
 
-protocol OrdersStoreProtocol
-{
+protocol OrdersStoreProtocol {
   // MARK: CRUD operations - Optional error
   
   func fetchOrders(completionHandler: (orders: [Order], error: OrdersStoreError?) -> Void)
@@ -61,24 +57,21 @@ typealias OrdersStoreCreateOrderCompletionHandler = (result: OrdersStoreResult<V
 typealias OrdersStoreUpdateOrderCompletionHandler = (result: OrdersStoreResult<Void>) -> Void
 typealias OrdersStoreDeleteOrderCompletionHandler = (result: OrdersStoreResult<Void>) -> Void
 
-enum OrdersStoreResult<U>
-{
+enum OrdersStoreResult<U> {
   case Success(result: U)
   case Failure(error: OrdersStoreError)
 }
 
 // MARK: - Orders store CRUD operation errors
 
-enum OrdersStoreError: Equatable, ErrorType
-{
+enum OrdersStoreError: Equatable, ErrorType {
   case CannotFetch(String)
   case CannotCreate(String)
   case CannotUpdate(String)
   case CannotDelete(String)
 }
 
-func ==(lhs: OrdersStoreError, rhs: OrdersStoreError) -> Bool
-{
+func ==(lhs: OrdersStoreError, rhs: OrdersStoreError) -> Bool {
   switch (lhs, rhs) {
   case (.CannotFetch(let a), .CannotFetch(let b)) where a == b: return true
   case (.CannotCreate(let a), .CannotCreate(let b)) where a == b: return true

--- a/CleanStoreTests/Scenes/CreateOrder/CreateOrderInteractorTests.swift
+++ b/CleanStoreTests/Scenes/CreateOrder/CreateOrderInteractorTests.swift
@@ -2,36 +2,31 @@
 import UIKit
 import XCTest
 
-class CreateOrderInteractorTests: XCTestCase
-{
+class CreateOrderInteractorTests: XCTestCase {
   // MARK: Subject under test
   
   var createOrderInteractor: CreateOrderInteractor!
   
   // MARK: Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     setupCreateOrderInteractor()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     super.tearDown()
   }
   
   // MARK: Test setup
   
-  func setupCreateOrderInteractor()
-  {
+  func setupCreateOrderInteractor() {
     createOrderInteractor = CreateOrderInteractor()
   }
   
   // MARK: Test doubles
   
-  class CreateOrderInteractorOutputSpy: CreateOrderInteractorOutput
-  {
+  class CreateOrderInteractorOutputSpy: CreateOrderInteractorOutput {
     var presentExpirationDateCalled = false
     
     func presentExpirationDate(response: CreateOrder_FormatExpirationDate_Response)
@@ -42,8 +37,7 @@ class CreateOrderInteractorTests: XCTestCase
   
   // MARK: Test expiration date
   
-  func testFormatExpirationDateShouldAskPresenterToFormatExpirationDate()
-  {
+  func testFormatExpirationDateShouldAskPresenterToFormatExpirationDate() {
     // Given
     let createOrderInteractorOutputSpy = CreateOrderInteractorOutputSpy()
     createOrderInteractor.output = createOrderInteractorOutputSpy
@@ -58,8 +52,7 @@ class CreateOrderInteractorTests: XCTestCase
   
   // MARK: Test shipping methods
   
-  func testShippingMethodsShouldReturnAllAvailableShippingMethods()
-  {
+  func testShippingMethodsShouldReturnAllAvailableShippingMethods() {
     // Given
     let allAvailableShippingMethods = [
       "Standard Shipping",

--- a/CleanStoreTests/Scenes/CreateOrder/CreateOrderPresenterTests.swift
+++ b/CleanStoreTests/Scenes/CreateOrder/CreateOrderPresenterTests.swift
@@ -2,36 +2,31 @@
 import UIKit
 import XCTest
 
-class CreateOrderPresenterTests: XCTestCase
-{
+class CreateOrderPresenterTests: XCTestCase {
   // MARK: Subject under test
   
   var createOrderPresenter: CreateOrderPresenter!
   
   // MARK: Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     setupCreateOrderPresenter()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     super.tearDown()
   }
   
   // MARK: Test setup
   
-  func setupCreateOrderPresenter()
-  {
+  func setupCreateOrderPresenter() {
     createOrderPresenter = CreateOrderPresenter()
   }
   
   // MARK: Test doubles
   
-  class CreateOrderPresenterOutputSpy: CreateOrderPresenterOutput
-  {
+  class CreateOrderPresenterOutputSpy: CreateOrderPresenterOutput {
     // MARK: Method call expectations
     var displayExpirationDateCalled = false
     
@@ -46,8 +41,7 @@ class CreateOrderPresenterTests: XCTestCase
     }
   }
   
-  class CreateOrderPresenterOutputMock: CreateOrderPresenterOutput
-  {
+  class CreateOrderPresenterOutputMock: CreateOrderPresenterOutput {
     // MARK: Method call expectations
     var displayExpirationDateCalled = false
     
@@ -75,8 +69,7 @@ class CreateOrderPresenterTests: XCTestCase
   
   // MARK: Test expiration date
   
-  func testPresentExpirationDateShouldConvertDateToStringUsingSpy()
-  {
+  func testPresentExpirationDateShouldConvertDateToStringUsingSpy() {
     // Given
     let createOrderPresenterOutputSpy = CreateOrderPresenterOutputSpy()
     createOrderPresenter.output = createOrderPresenterOutputSpy
@@ -97,8 +90,7 @@ class CreateOrderPresenterTests: XCTestCase
     XCTAssertEqual(returnedDate, expectedDate, "Presenting an expiration date should convert date to string")
   }
   
-  func testPresentExpirationDateShouldAskViewControllerToDisplayDateStringUsingSpy()
-  {
+  func testPresentExpirationDateShouldAskViewControllerToDisplayDateStringUsingSpy() {
     // Given
     let createOrderPresenterOutputSpy = CreateOrderPresenterOutputSpy()
     createOrderPresenter.output = createOrderPresenterOutputSpy
@@ -111,8 +103,7 @@ class CreateOrderPresenterTests: XCTestCase
     XCTAssert(createOrderPresenterOutputSpy.displayExpirationDateCalled, "Presenting an expiration date should ask view controller to display date string")
   }
   
-  func testPresentExpirationDateShouldConvertDateToStringUsingMock()
-  {
+  func testPresentExpirationDateShouldConvertDateToStringUsingMock() {
     // Given
     let createOrderPresenterOutputMock = CreateOrderPresenterOutputMock()
     createOrderPresenter.output = createOrderPresenterOutputMock
@@ -132,8 +123,7 @@ class CreateOrderPresenterTests: XCTestCase
     XCTAssert(createOrderPresenterOutputMock.verifyExpirationDateIsFormattedAs(expectedDate), "Presenting an expiration date should convert date to string")
   }
   
-  func testPresentExpirationDateShouldAskViewControllerToDisplayDateStringUsingMock()
-  {
+  func testPresentExpirationDateShouldAskViewControllerToDisplayDateStringUsingMock() {
     // Given
     let createOrderPresenterOutputMock = CreateOrderPresenterOutputMock()
     createOrderPresenter.output = createOrderPresenterOutputMock

--- a/CleanStoreTests/Scenes/CreateOrder/CreateOrderViewControllerTests.swift
+++ b/CleanStoreTests/Scenes/CreateOrder/CreateOrderViewControllerTests.swift
@@ -2,8 +2,7 @@
 import UIKit
 import XCTest
 
-class CreateOrderViewControllerTests: XCTestCase
-{
+class CreateOrderViewControllerTests: XCTestCase {
   // MARK: Subject under test
   
   var createOrderViewController: CreateOrderViewController!
@@ -11,23 +10,20 @@ class CreateOrderViewControllerTests: XCTestCase
   
   // MARK: Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     window = UIWindow()
     setupCreateOrderViewController()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     window = nil
     super.tearDown()
   }
   
   // MARK: Test setup
   
-  func setupCreateOrderViewController()
-  {
+  func setupCreateOrderViewController() {
     let bundle = NSBundle.mainBundle()
     let storyboard = UIStoryboard(name: "Main", bundle: bundle)
     createOrderViewController = storyboard.instantiateViewControllerWithIdentifier("CreateOrderViewController") as! CreateOrderViewController
@@ -35,16 +31,14 @@ class CreateOrderViewControllerTests: XCTestCase
     addViewToWindow()
   }
   
-  func addViewToWindow()
-  {
+  func addViewToWindow() {
     window.addSubview(createOrderViewController.view)
     NSRunLoop.currentRunLoop().runUntilDate(NSDate())
   }
   
   // MARK: Test doubles
   
-  class CreateOrderViewControllerOutputSpy: CreateOrderViewControllerOutput
-  {
+  class CreateOrderViewControllerOutputSpy: CreateOrderViewControllerOutput {
     // MARK: Method call expectations
     var formatExpirationDateCalled = false
     
@@ -64,8 +58,7 @@ class CreateOrderViewControllerTests: XCTestCase
   
   // MARK: Test expiration date
   
-  func testDisplayExpirationDateShouldDisplayDateStringInTextField()
-  {
+  func testDisplayExpirationDateShouldDisplayDateStringInTextField() {
     // Given
     let viewModel = CreateOrder_FormatExpirationDate_ViewModel(date: "6/29/07")
     
@@ -77,8 +70,7 @@ class CreateOrderViewControllerTests: XCTestCase
     XCTAssertEqual(displayedDate, "6/29/07", "Displaying an expiration date should display the date string in the expiration date text field")
   }
   
-  func testExpirationDatePickerValueChangedShouldFormatSelectedDate()
-  {
+  func testExpirationDatePickerValueChangedShouldFormatSelectedDate() {
     // Given
     let createOrderViewControllerOutputSpy = CreateOrderViewControllerOutputSpy()
     createOrderViewController.output = createOrderViewControllerOutputSpy
@@ -101,8 +93,7 @@ class CreateOrderViewControllerTests: XCTestCase
   
   // MARK: Test shipping method
   
-  func testNumberOfComponentsInPickerViewShouldReturnOneComponent()
-  {
+  func testNumberOfComponentsInPickerViewShouldReturnOneComponent() {
     // Given
     let pickerView = createOrderViewController.shippingMethodPicker
     
@@ -113,8 +104,7 @@ class CreateOrderViewControllerTests: XCTestCase
     XCTAssertEqual(numberOfComponents, 1, "The number of components in the shipping method picker should be 1")
   }
   
-  func testNumberOfRowsInFirstComponentOfPickerViewShouldEqualNumberOfAvailableShippingMethods()
-  {
+  func testNumberOfRowsInFirstComponentOfPickerViewShouldEqualNumberOfAvailableShippingMethods() {
     // Given
     let pickerView = createOrderViewController.shippingMethodPicker
     
@@ -126,8 +116,7 @@ class CreateOrderViewControllerTests: XCTestCase
     XCTAssertEqual(numberOfRows, numberOfAvailableShippingtMethods, "The number of rows in the first component of shipping method picker should equal to the number of available shipping methods")
   }
   
-  func testShippingMethodPickerShouldDisplayProperTitles()
-  {
+  func testShippingMethodPickerShouldDisplayProperTitles() {
     // Given
     let pickerView = createOrderViewController.shippingMethodPicker
     
@@ -149,8 +138,7 @@ class CreateOrderViewControllerTests: XCTestCase
     XCTAssertEqual(returnedTitles[2], expectedTitles[2], "The shipping method picker should display proper titles")
   }
   
-  func testSelectingShippingMethodInThePickerShouldDisplayTheSelectedShippingMethodToUser()
-  {
+  func testSelectingShippingMethodInThePickerShouldDisplayTheSelectedShippingMethodToUser() {
     // Given
     let pickerView = createOrderViewController.shippingMethodPicker
     
@@ -165,8 +153,7 @@ class CreateOrderViewControllerTests: XCTestCase
   
   // MARK: Test text fields
   
-  func testCursorFocusShouldMoveToNextTextFieldWhenUserTapsReturnKey()
-  {
+  func testCursorFocusShouldMoveToNextTextFieldWhenUserTapsReturnKey() {
     // Given
     let currentTextField = createOrderViewController.textFields[0]
     let nextTextField = createOrderViewController.textFields[1]
@@ -180,8 +167,7 @@ class CreateOrderViewControllerTests: XCTestCase
     XCTAssert(nextTextField.isFirstResponder(), "Next text field should gain keyboard focus")
   }
   
-  func testKeyboardShouldBeDismissedWhenUserTapsReturnKeyWhenFocusIsInLastTextField()
-  {
+  func testKeyboardShouldBeDismissedWhenUserTapsReturnKeyWhenFocusIsInLastTextField() {
     // Given
     
     // Scroll to the bottom of table view so the last text field is visible and its gesture recognizer is set up
@@ -201,8 +187,7 @@ class CreateOrderViewControllerTests: XCTestCase
     XCTAssert(!lastTextField.isFirstResponder(), "Last text field should lose keyboard focus")
   }
   
-  func testTextFieldShouldHaveFocusWhenUserTapsOnTableViewRow()
-  {
+  func testTextFieldShouldHaveFocusWhenUserTapsOnTableViewRow() {
     // Given
     
     // When
@@ -216,8 +201,7 @@ class CreateOrderViewControllerTests: XCTestCase
   
   // MARK: Test picker configs when view is loaded
   
-  func testCreateOrderViewControllerShouldConfigurePickersWhenViewIsLoaded()
-  {
+  func testCreateOrderViewControllerShouldConfigurePickersWhenViewIsLoaded() {
     // Given
     
     // When

--- a/CleanStoreTests/Scenes/ListOrders/ListOrdersInteractorTests.swift
+++ b/CleanStoreTests/Scenes/ListOrders/ListOrdersInteractorTests.swift
@@ -12,36 +12,31 @@
 @testable import CleanStore
 import XCTest
 
-class ListOrdersInteractorTests: XCTestCase
-{
+class ListOrdersInteractorTests: XCTestCase {
   // MARK: Subject under test
   
   var sut: ListOrdersInteractor!
   
   // MARK: Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     setupListOrdersInteractor()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     super.tearDown()
   }
   
   // MARK: Test setup
   
-  func setupListOrdersInteractor()
-  {
+  func setupListOrdersInteractor() {
     sut = ListOrdersInteractor()
   }
   
   // MARK: Test doubles
   
-  class ListOrdersInteractorOutputSpy: ListOrdersInteractorOutput
-  {
+  class ListOrdersInteractorOutputSpy: ListOrdersInteractorOutput {
     // MARK: Method call expectations
     var presentFetchedOrdersCalled = false
     
@@ -52,8 +47,7 @@ class ListOrdersInteractorTests: XCTestCase
     }
   }
   
-  class OrdersWorkerSpy: OrdersWorker
-  {
+  class OrdersWorkerSpy: OrdersWorker {
     // MARK: Method call expectations
     var fetchOrdersCalled = false
     
@@ -67,8 +61,7 @@ class ListOrdersInteractorTests: XCTestCase
   
   // MARK: Tests
   
-  func testFetchOrdersShouldAskOrdersWorkerToFetchOrdersAndPresenterToFormatResult()
-  {
+  func testFetchOrdersShouldAskOrdersWorkerToFetchOrdersAndPresenterToFormatResult() {
     // Given
     let listOrdersInteractorOutputSpy = ListOrdersInteractorOutputSpy()
     sut.output = listOrdersInteractorOutputSpy

--- a/CleanStoreTests/Scenes/ListOrders/ListOrdersPresenterTests.swift
+++ b/CleanStoreTests/Scenes/ListOrders/ListOrdersPresenterTests.swift
@@ -12,36 +12,31 @@
 @testable import CleanStore
 import XCTest
 
-class ListOrdersPresenterTests: XCTestCase
-{
+class ListOrdersPresenterTests: XCTestCase {
   // MARK: Subject under test
   
   var sut: ListOrdersPresenter!
   
   // MARK: Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     setupListOrdersPresenter()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     super.tearDown()
   }
   
   // MARK: Test setup
   
-  func setupListOrdersPresenter()
-  {
+  func setupListOrdersPresenter() {
     sut = ListOrdersPresenter()
   }
   
   // MARK: Test doubles
   
-  class ListOrdersPresenterOutputSpy: ListOrdersPresenterOutput
-  {
+  class ListOrdersPresenterOutputSpy: ListOrdersPresenterOutput {
     // MARK: Method call expectations
     var displayFetchedOrdersCalled = false
     
@@ -58,8 +53,7 @@ class ListOrdersPresenterTests: XCTestCase
   
   // MARK: Tests
   
-  func testPresentFetchedOrdersShouldFormatFetchedOrdersForDisplay()
-  {
+  func testPresentFetchedOrdersShouldFormatFetchedOrdersForDisplay() {
     // Given
     let listOrdersPresenterOutputSpy = ListOrdersPresenterOutputSpy()
     sut.output = listOrdersPresenterOutputSpy
@@ -87,8 +81,7 @@ class ListOrdersPresenterTests: XCTestCase
     }
   }
   
-  func testPresentFetchedOrdersShouldAskViewControllerToDisplayFetchedOrders()
-  {
+  func testPresentFetchedOrdersShouldAskViewControllerToDisplayFetchedOrders() {
     // Given
     let listOrdersPresenterOutputSpy = ListOrdersPresenterOutputSpy()
     sut.output = listOrdersPresenterOutputSpy

--- a/CleanStoreTests/Scenes/ListOrders/ListOrdersViewControllerTests.swift
+++ b/CleanStoreTests/Scenes/ListOrders/ListOrdersViewControllerTests.swift
@@ -12,8 +12,7 @@
 @testable import CleanStore
 import XCTest
 
-class ListOrdersViewControllerTests: XCTestCase
-{
+class ListOrdersViewControllerTests: XCTestCase {
   // MARK: Subject under test
   
   var sut: ListOrdersViewController!
@@ -21,38 +20,33 @@ class ListOrdersViewControllerTests: XCTestCase
   
   // MARK: Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     window = UIWindow()
     setupListOrdersViewController()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     window = nil
     super.tearDown()
   }
   
   // MARK: Test setup
   
-  func setupListOrdersViewController()
-  {
+  func setupListOrdersViewController() {
     let bundle = NSBundle.mainBundle()
     let storyboard = UIStoryboard(name: "Main", bundle: bundle)
     sut = storyboard.instantiateViewControllerWithIdentifier("ListOrdersViewController") as! ListOrdersViewController
   }
   
-  func loadView()
-  {
+  func loadView() {
     window.addSubview(sut.view)
     NSRunLoop.currentRunLoop().runUntilDate(NSDate())
   }
   
   // MARK: Test doubles
   
-  class ListOrdersViewControllerOutputSpy: ListOrdersViewControllerOutput
-  {
+  class ListOrdersViewControllerOutputSpy: ListOrdersViewControllerOutput {
     // MARK: Method call expectations
     var fetchOrdersCalled = false
     
@@ -63,8 +57,7 @@ class ListOrdersViewControllerTests: XCTestCase
     }
   }
   
-  class TableViewSpy: UITableView
-  {
+  class TableViewSpy: UITableView {
     // MARK: Method call expectations
     var reloadDataCalled = false
     
@@ -77,8 +70,7 @@ class ListOrdersViewControllerTests: XCTestCase
   
   // MARK: Tests
   
-  func testShouldFetchOrdersWhenViewIsLoaded()
-  {
+  func testShouldFetchOrdersWhenViewIsLoaded() {
     // Given
     let listOrdersViewControllerOutputSpy = ListOrdersViewControllerOutputSpy()
     sut.output = listOrdersViewControllerOutputSpy
@@ -90,8 +82,7 @@ class ListOrdersViewControllerTests: XCTestCase
     XCTAssert(listOrdersViewControllerOutputSpy.fetchOrdersCalled, "Should fetch orders when the view is loaded")
   }
   
-  func testShouldDisplayFetchedOrders()
-  {
+  func testShouldDisplayFetchedOrders() {
     // Given
     let tableViewSpy = TableViewSpy()
     sut.tableView = tableViewSpy
@@ -106,8 +97,7 @@ class ListOrdersViewControllerTests: XCTestCase
     XCTAssert(tableViewSpy.reloadDataCalled, "Displaying fetched orders should reload the table view")
   }
   
-  func testNumberOfSectionsInTableViewShouldAlwaysBeOne()
-  {
+  func testNumberOfSectionsInTableViewShouldAlwaysBeOne() {
     // Given
     let tableView = sut.tableView
     
@@ -118,8 +108,7 @@ class ListOrdersViewControllerTests: XCTestCase
     XCTAssertEqual(numberOfSections, 1, "The number of table view sections should always be 1")
   }
   
-  func testNumberOfRowsInAnySectionShouldEqaulNumberOfOrdersToDisplay()
-  {
+  func testNumberOfRowsInAnySectionShouldEqaulNumberOfOrdersToDisplay() {
     // Given
     let tableView = sut.tableView
     let testDisplayedOrders = [ListOrders_FetchOrders_ViewModel.DisplayedOrder(id: "abc123", date: "6/29/07", email: "amy.apple@clean-swift.com", name: "Amy Apple", total: "$1.23")]
@@ -132,8 +121,7 @@ class ListOrdersViewControllerTests: XCTestCase
     XCTAssertEqual(numberOfRows, testDisplayedOrders.count, "The number of table view rows should equal the number of orders to display")
   }
   
-  func testShouldConfigureTableViewCellToDisplayOrder()
-  {
+  func testShouldConfigureTableViewCellToDisplayOrder() {
     // Given
     let tableView = sut.tableView
     let testDisplayedOrders = [ListOrders_FetchOrders_ViewModel.DisplayedOrder(id: "abc123", date: "6/29/07", email: "amy.apple@clean-swift.com", name: "Amy Apple", total: "$1.23")]

--- a/CleanStoreTests/Services/OrdersAPITests.swift
+++ b/CleanStoreTests/Services/OrdersAPITests.swift
@@ -1,8 +1,7 @@
 @testable import CleanStore
 import XCTest
 
-class OrdersAPITests: XCTestCase
-{
+class OrdersAPITests: XCTestCase {
   // MARK: - Subject under test
   
   var sut: OrdersAPI!
@@ -10,21 +9,18 @@ class OrdersAPITests: XCTestCase
   
   // MARK: - Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     setupOrdersAPI()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     super.tearDown()
   }
   
   // MARK: - Test setup
   
-  func setupOrdersAPI()
-  {
+  func setupOrdersAPI() {
     sut = OrdersAPI()
     testOrders = [
       Order(id: "abc123", date: NSDate(), email: "amy.apple@clean-swift.com", firstName: "Amy", lastName: "Apple", total: NSDecimalNumber(string: "1.23")),
@@ -34,8 +30,7 @@ class OrdersAPITests: XCTestCase
   
   // MARK: - Test CRUD operations - Optional error
   
-  func testFetchOrdersShouldReturnListOfOrders_OptionalError()
-  {
+  func testFetchOrdersShouldReturnListOfOrders_OptionalError() {
     // Given
     
     // When
@@ -43,8 +38,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testFetchOrderShouldReturnOrder_OptionalError()
-  {
+  func testFetchOrderShouldReturnOrder_OptionalError() {
     // Given
     
     // When
@@ -52,8 +46,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testCreateOrderShouldCreateNewOrder_OptionalError()
-  {
+  func testCreateOrderShouldCreateNewOrder_OptionalError() {
     // Given
     
     // When
@@ -61,8 +54,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testUpdateOrderShouldUpdateExistingOrder_OptionalError()
-  {
+  func testUpdateOrderShouldUpdateExistingOrder_OptionalError() {
     // Given
     
     // When
@@ -70,8 +62,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testDeleteOrderShouldDeleteExistingOrder_OptionalError()
-  {
+  func testDeleteOrderShouldDeleteExistingOrder_OptionalError() {
     // Given
     
     // When
@@ -81,8 +72,7 @@ class OrdersAPITests: XCTestCase
   
   // MARK: - Test CRUD operations - Generic enum result type
   
-  func testFetchOrdersShouldReturnListOfOrders_GenericEnumResultType()
-  {
+  func testFetchOrdersShouldReturnListOfOrders_GenericEnumResultType() {
     // Given
     
     // When
@@ -90,8 +80,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testFetchOrderShouldReturnOrder_GenericEnumResultType()
-  {
+  func testFetchOrderShouldReturnOrder_GenericEnumResultType() {
     // Given
     
     // When
@@ -99,8 +88,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testCreateOrderShouldCreateNewOrder_GenericEnumResultType()
-  {
+  func testCreateOrderShouldCreateNewOrder_GenericEnumResultType() {
     // Given
     
     // When
@@ -108,8 +96,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testUpdateOrderShouldUpdateExistingOrder_GenericEnumResultType()
-  {
+  func testUpdateOrderShouldUpdateExistingOrder_GenericEnumResultType() {
     // Given
     
     // When
@@ -117,8 +104,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testDeleteOrderShouldDeleteExistingOrder_GenericEnumResultType()
-  {
+  func testDeleteOrderShouldDeleteExistingOrder_GenericEnumResultType() {
     // Given
     
     // When
@@ -128,8 +114,7 @@ class OrdersAPITests: XCTestCase
   
   // MARK: - Test CRUD operations - Inner closure
   
-  func testFetchOrdersShouldReturnListOfOrders_InnerClosure()
-  {
+  func testFetchOrdersShouldReturnListOfOrders_InnerClosure() {
     // Given
     
     // When
@@ -137,8 +122,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testFetchOrderShouldReturnOrder_InnerClosure()
-  {
+  func testFetchOrderShouldReturnOrder_InnerClosure() {
     // Given
     
     // When
@@ -146,8 +130,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testCreateOrderShouldCreateNewOrder_InnerClosure()
-  {
+  func testCreateOrderShouldCreateNewOrder_InnerClosure() {
     // Given
     
     // When
@@ -155,8 +138,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testUpdateOrderShouldUpdateExistingOrder_InnerClosure()
-  {
+  func testUpdateOrderShouldUpdateExistingOrder_InnerClosure() {
     // Given
     
     // When
@@ -164,8 +146,7 @@ class OrdersAPITests: XCTestCase
     // Then
   }
   
-  func testDeleteOrderShouldDeleteExistingOrder_InnerClosure()
-  {
+  func testDeleteOrderShouldDeleteExistingOrder_InnerClosure() {
     // Given
     
     // When

--- a/CleanStoreTests/Services/OrdersCoreDataStoreTests.swift
+++ b/CleanStoreTests/Services/OrdersCoreDataStoreTests.swift
@@ -2,8 +2,7 @@
 import XCTest
 import CoreData
 
-class OrdersCoreDataStoreTests: XCTestCase
-{
+class OrdersCoreDataStoreTests: XCTestCase {
   // MARK: - Subject under test
   
   var sut: OrdersCoreDataStore!
@@ -11,22 +10,19 @@ class OrdersCoreDataStoreTests: XCTestCase
   
   // MARK: - Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     setupOrdersCoreDataStore()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     sut = nil
     super.tearDown()
   }
   
   // MARK: - Test setup
   
-  func setupOrdersCoreDataStore()
-  {
+  func setupOrdersCoreDataStore() {
     sut = OrdersCoreDataStore()
     
     deleteAllOrdersInOrdersCoreDataStore()
@@ -46,8 +42,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     }
   }
   
-  func deleteAllOrdersInOrdersCoreDataStore()
-  {
+  func deleteAllOrdersInOrdersCoreDataStore() {
     var allOrders = [Order]()
     let fetchOrdersExpectation = expectationWithDescription("Wait for fetchOrder() to return")
     sut.fetchOrders { (orders: () throws -> [Order]) -> Void in
@@ -69,8 +64,7 @@ class OrdersCoreDataStoreTests: XCTestCase
   
   // MARK: - Test CRUD operations - Optional error
   
-  func testFetchOrdersShouldReturnListOfOrders_OptionalError()
-  {
+  func testFetchOrdersShouldReturnListOfOrders_OptionalError() {
     // Given
     
     // When
@@ -90,8 +84,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     }
   }
   
-  func testFetchOrderShouldReturnOrder_OptionalError()
-  {
+  func testFetchOrderShouldReturnOrder_OptionalError() {
     // Given
     let orderToFetch = testOrders.first!
     
@@ -109,8 +102,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     XCTAssertEqual(returnedOrder, orderToFetch, "fetchOrder() should return an order")
   }
   
-  func testCreateOrderShouldCreateNewOrder_OptionalError()
-  {
+  func testCreateOrderShouldCreateNewOrder_OptionalError() {
     // Given
     let orderToCreate = Order(id: "ghi789", date: NSDate(), email: "colin.code@clean-swift.com", firstName: "Colin", lastName: "Code", total: NSDecimalNumber(string: "7.89"))
     
@@ -135,8 +127,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     XCTAssertEqual(returnedOrder, orderToCreate, "createOrder() should create a new order")
   }
   
-  func testUpdateOrderShouldUpdateExistingOrder_OptionalError()
-  {
+  func testUpdateOrderShouldUpdateExistingOrder_OptionalError() {
     // Given
     var orderToUpdate = testOrders.first!
     let tomorrow = NSDate(timeIntervalSinceNow: 24*60*60)
@@ -163,8 +154,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     XCTAssertEqual(updatedOrder, orderToUpdate, "updateOrder() should update an existing order")
   }
   
-  func testDeleteOrderShouldDeleteExistingOrder_OptionalError()
-  {
+  func testDeleteOrderShouldDeleteExistingOrder_OptionalError() {
     // Given
     let orderToDelete = testOrders.first!
     
@@ -194,8 +184,7 @@ class OrdersCoreDataStoreTests: XCTestCase
   
   // MARK: - Test CRUD operations - Generic enum result type
   
-  func testFetchOrdersShouldReturnListOfOrders_GenericEnumResultType()
-  {
+  func testFetchOrdersShouldReturnListOfOrders_GenericEnumResultType() {
     // Given
     
     // When
@@ -220,8 +209,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     }
   }
   
-  func testFetchOrderShouldReturnOrder_GenericEnumResultType()
-  {
+  func testFetchOrderShouldReturnOrder_GenericEnumResultType() {
     // Given
     let orderToFetch = testOrders.first!
     
@@ -244,8 +232,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     XCTAssertEqual(returnedOrder, orderToFetch, "fetchOrder() should return an order")
   }
   
-  func testCreateOrderShouldCreateNewOrder_GenericEnumResultType()
-  {
+  func testCreateOrderShouldCreateNewOrder_GenericEnumResultType() {
     // Given
     let orderToCreate = Order(id: "ghi789", date: NSDate(), email: "colin.code@clean-swift.com", firstName: "Colin", lastName: "Code", total: NSDecimalNumber(string: "7.89"))
     
@@ -270,8 +257,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     XCTAssertEqual(returnedOrder, orderToCreate, "createOrder() should create a new order")
   }
   
-  func testUpdateOrderShouldUpdateExistingOrder_GenericEnumResultType()
-  {
+  func testUpdateOrderShouldUpdateExistingOrder_GenericEnumResultType() {
     // Given
     var orderToUpdate = testOrders.first!
     let tomorrow = NSDate(timeIntervalSinceNow: 24*60*60)
@@ -309,8 +295,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     XCTAssertEqual(updatedOrder, orderToUpdate, "updateOrder() should update an existing order")
   }
   
-  func testDeleteOrderShouldDeleteExistingOrder_GenericEnumResultType()
-  {
+  func testDeleteOrderShouldDeleteExistingOrder_GenericEnumResultType() {
     // Given
     let orderToDelete = testOrders.first!
     
@@ -344,8 +329,7 @@ class OrdersCoreDataStoreTests: XCTestCase
   
   // MARK: - Test CRUD operations - Inner closure
   
-  func testFetchOrdersShouldReturnListOfOrders_InnerClosure()
-  {
+  func testFetchOrdersShouldReturnListOfOrders_InnerClosure() {
     // Given
     
     // When
@@ -365,8 +349,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     }
   }
   
-  func testFetchOrderShouldReturnOrder_InnerClosure()
-  {
+  func testFetchOrderShouldReturnOrder_InnerClosure() {
     // Given
     let orderToFetch = testOrders.first!
     
@@ -384,8 +367,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     XCTAssertEqual(returnedOrder, orderToFetch, "fetchOrder() should return an order")
   }
   
-  func testCreateOrderShouldCreateNewOrder_InnerClosure()
-  {
+  func testCreateOrderShouldCreateNewOrder_InnerClosure() {
     // Given
     let orderToCreate = Order(id: "ghi789", date: NSDate(), email: "colin.code@clean-swift.com", firstName: "Colin", lastName: "Code", total: NSDecimalNumber(string: "7.89"))
     
@@ -411,8 +393,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     XCTAssertEqual(returnedOrder, orderToCreate, "createOrder() should create a new order")
   }
   
-  func testUpdateOrderShouldUpdateExistingOrder_InnerClosure()
-  {
+  func testUpdateOrderShouldUpdateExistingOrder_InnerClosure() {
     // Given
     var orderToUpdate = testOrders.first!
     let tomorrow = NSDate(timeIntervalSinceNow: 24*60*60)
@@ -440,8 +421,7 @@ class OrdersCoreDataStoreTests: XCTestCase
     XCTAssertEqual(updatedOrder, orderToUpdate, "updateOrder() should update an existing order")
   }
   
-  func testDeleteOrderShouldDeleteExistingOrder_InnerClosure()
-  {
+  func testDeleteOrderShouldDeleteExistingOrder_InnerClosure() {
     // Given
     let orderToDelete = testOrders.first!
     

--- a/CleanStoreTests/Services/OrdersMemStoreTests.swift
+++ b/CleanStoreTests/Services/OrdersMemStoreTests.swift
@@ -1,8 +1,7 @@
 @testable import CleanStore
 import XCTest
 
-class OrdersMemStoreTests: XCTestCase
-{
+class OrdersMemStoreTests: XCTestCase {
   // MARK: - Subject under test
   
   var sut: OrdersMemStore!
@@ -10,22 +9,19 @@ class OrdersMemStoreTests: XCTestCase
   
   // MARK: - Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     setupOrdersMemStore()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     resetOrdersMemStore()
     super.tearDown()
   }
   
   // MARK: - Test setup
   
-  func setupOrdersMemStore()
-  {
+  func setupOrdersMemStore() {
     sut = OrdersMemStore()
     
     testOrders = [
@@ -36,16 +32,14 @@ class OrdersMemStoreTests: XCTestCase
     sut.orders = testOrders
   }
   
-  func resetOrdersMemStore()
-  {
+  func resetOrdersMemStore() {
     sut.orders = []
     sut = nil
   }
   
   // MARK: - Test CRUD operations - Optional error
   
-  func testFetchOrdersShouldReturnListOfOrders_OptionalError()
-  {
+  func testFetchOrdersShouldReturnListOfOrders_OptionalError() {
     // Given
     
     // When
@@ -65,8 +59,7 @@ class OrdersMemStoreTests: XCTestCase
     }
   }
   
-  func testFetchOrderShouldReturnOrder_OptionalError()
-  {
+  func testFetchOrderShouldReturnOrder_OptionalError() {
     // Given
     let orderToFetch = testOrders.first!
     
@@ -84,8 +77,7 @@ class OrdersMemStoreTests: XCTestCase
     XCTAssertEqual(returnedOrder, orderToFetch, "fetchOrder() should return an order")
   }
   
-  func testCreateOrderShouldCreateNewOrder_OptionalError()
-  {
+  func testCreateOrderShouldCreateNewOrder_OptionalError() {
     // Given
     let orderToCreate = Order(id: "ghi789", date: NSDate(), email: "colin.code@clean-swift.com", firstName: "Colin", lastName: "Code", total: NSDecimalNumber(string: "7.89"))
     
@@ -110,8 +102,7 @@ class OrdersMemStoreTests: XCTestCase
     XCTAssertEqual(createdOrder, orderToCreate, "createOrder() should create a new order")
   }
   
-  func testUpdateOrderShouldUpdateExistingOrder_OptionalError()
-  {
+  func testUpdateOrderShouldUpdateExistingOrder_OptionalError() {
     // Given
     var orderToUpdate = testOrders.first!
     let tomorrow = NSDate(timeIntervalSinceNow: 24*60*60)
@@ -138,8 +129,7 @@ class OrdersMemStoreTests: XCTestCase
     XCTAssertEqual(updatedOrder, orderToUpdate, "updateOrder() should update an existing order")
   }
   
-  func testDeleteOrderShouldDeleteExistingOrder_OptionalError()
-  {
+  func testDeleteOrderShouldDeleteExistingOrder_OptionalError() {
     // Given
     let orderToDelete = testOrders.first!
     
@@ -169,8 +159,7 @@ class OrdersMemStoreTests: XCTestCase
   
   // MARK: - Test CRUD operations - Generic enum result type
   
-  func testFetchOrdersShouldReturnListOfOrders_GenericEnumResultType()
-  {
+  func testFetchOrdersShouldReturnListOfOrders_GenericEnumResultType() {
     // Given
     
     // When
@@ -195,8 +184,7 @@ class OrdersMemStoreTests: XCTestCase
     }
   }
   
-  func testFetchOrderShouldReturnOrder_GenericEnumResultType()
-  {
+  func testFetchOrderShouldReturnOrder_GenericEnumResultType() {
     // Given
     let orderToFetch = testOrders.first!
     
@@ -219,8 +207,7 @@ class OrdersMemStoreTests: XCTestCase
     XCTAssertEqual(returnedOrder, orderToFetch, "fetchOrder() should return an order")
   }
   
-  func testCreateOrderShouldCreateNewOrder_GenericEnumResultType()
-  {
+  func testCreateOrderShouldCreateNewOrder_GenericEnumResultType() {
     // Given
     let orderToCreate = Order(id: "ghi789", date: NSDate(), email: "colin.code@clean-swift.com", firstName: "Colin", lastName: "Code", total: NSDecimalNumber(string: "7.89"))
     
@@ -256,8 +243,7 @@ class OrdersMemStoreTests: XCTestCase
     XCTAssertEqual(createdOrder, orderToCreate, "createOrder() should create a new order")
   }
   
-  func testUpdateOrderShouldUpdateExistingOrder_GenericEnumResultType()
-  {
+  func testUpdateOrderShouldUpdateExistingOrder_GenericEnumResultType() {
     // Given
     var orderToUpdate = testOrders.first!
     let tomorrow = NSDate(timeIntervalSinceNow: 24*60*60)
@@ -295,8 +281,7 @@ class OrdersMemStoreTests: XCTestCase
     XCTAssertEqual(updatedOrder, orderToUpdate, "updateOrder() should update an existing order")
   }
   
-  func testDeleteOrderShouldDeleteExistingOrder_GenericEnumResultType()
-  {
+  func testDeleteOrderShouldDeleteExistingOrder_GenericEnumResultType() {
     // Given
     let orderToDelete = testOrders.first!
     
@@ -330,8 +315,7 @@ class OrdersMemStoreTests: XCTestCase
   
   // MARK: - Test CRUD operations - Inner closure
   
-  func testFetchOrdersShouldReturnListOfOrders_InnerClosure()
-  {
+  func testFetchOrdersShouldReturnListOfOrders_InnerClosure() {
     // Given
     
     // When
@@ -351,8 +335,7 @@ class OrdersMemStoreTests: XCTestCase
     }
   }
   
-  func testFetchOrderShouldReturnOrder_InnerClosure()
-  {
+  func testFetchOrderShouldReturnOrder_InnerClosure() {
     // Given
     let orderToFetch = testOrders.first!
     
@@ -370,8 +353,7 @@ class OrdersMemStoreTests: XCTestCase
     XCTAssertEqual(returnedOrder, orderToFetch, "fetchOrder() should return an order")
   }
   
-  func testCreateOrderShouldCreateNewOrder_InnerClosure()
-  {
+  func testCreateOrderShouldCreateNewOrder_InnerClosure() {
     // Given
     let orderToCreate = Order(id: "ghi789", date: NSDate(), email: "colin.code@clean-swift.com", firstName: "Colin", lastName: "Code", total: NSDecimalNumber(string: "7.89"))
     
@@ -397,8 +379,7 @@ class OrdersMemStoreTests: XCTestCase
     XCTAssertEqual(createdOrder, orderToCreate, "createOrder() should create a new order")
   }
   
-  func testUpdateOrderShouldUpdateExistingOrder_InnerClosure()
-  {
+  func testUpdateOrderShouldUpdateExistingOrder_InnerClosure() {
     // Given
     var orderToUpdate = testOrders.first!
     let tomorrow = NSDate(timeIntervalSinceNow: 24*60*60)
@@ -426,8 +407,7 @@ class OrdersMemStoreTests: XCTestCase
     XCTAssertEqual(updatedOrder, orderToUpdate, "updateOrder() should update an existing order")
   }
   
-  func testDeleteOrderShouldDeleteExistingOrder_InnerClosure()
-  {
+  func testDeleteOrderShouldDeleteExistingOrder_InnerClosure() {
     // Given
     let orderToDelete = testOrders.first!
     

--- a/CleanStoreTests/TheLittleMocker.swift
+++ b/CleanStoreTests/TheLittleMocker.swift
@@ -9,81 +9,64 @@
 import UIKit
 import XCTest
 
-protocol Authorizer
-{
+protocol Authorizer {
   func authorize(username: String, password: String) -> Bool?
 }
 
-class DummyAuthorizer: Authorizer
-{
-  func authorize(username: String, password: String) -> Bool?
-  {
+class DummyAuthorizer: Authorizer {
+  func authorize(username: String, password: String) -> Bool? {
     return nil
   }
 }
 
-class AcceptingAuthorizerStub: Authorizer
-{
-  func authorize(username: String, password: String) -> Bool?
-  {
+class AcceptingAuthorizerStub: Authorizer {
+  func authorize(username: String, password: String) -> Bool? {
     return true
   }
 }
 
-class AcceptingAuthorizerSpy: Authorizer
-{
+class AcceptingAuthorizerSpy: Authorizer {
   var authorizeWasCalled = false
   
-  func authorize(username: String, password: String) -> Bool?
-  {
+  func authorize(username: String, password: String) -> Bool? {
     authorizeWasCalled = true
     return true
   }
 }
 
-class AcceptingAuthorizerVerificationMock: Authorizer
-{
+class AcceptingAuthorizerVerificationMock: Authorizer {
   var authorizeWasCalled = false
   
-  func authorize(username: String, password: String) -> Bool?
-  {
+  func authorize(username: String, password: String) -> Bool? {
     authorizeWasCalled = true
     return true
   }
   
-  func verify() -> Bool
-  {
+  func verify() -> Bool {
     return authorizeWasCalled
   }
 }
 
-class AcceptingAuthorizerFake: Authorizer
-{
-  func authorize(username: String, password: String) -> Bool?
-  {
+class AcceptingAuthorizerFake: Authorizer {
+  func authorize(username: String, password: String) -> Bool? {
     return username == "Bob"
   }
 }
 
-class System
-{
+class System {
   var authorizer: Authorizer
   
-  init(authorizer: Authorizer)
-  {
+  init(authorizer: Authorizer) {
     self.authorizer = authorizer
   }
   
-  func loginCount() -> Int
-  {
+  func loginCount() -> Int {
     return 0
   }
 }
 
-class TheLittleMocker: XCTestCase
-{
-  func testNewlyCreatedSystem_hasNoLoggedInUsers()
-  {
+class TheLittleMocker: XCTestCase {
+  func testNewlyCreatedSystem_hasNoLoggedInUsers() {
     let system = System(authorizer: DummyAuthorizer())
     XCTAssert(system.loginCount() == 0, "Pass")
   }

--- a/CleanStoreTests/Workers/OrdersWorkerTests.swift
+++ b/CleanStoreTests/Workers/OrdersWorkerTests.swift
@@ -1,36 +1,31 @@
 @testable import CleanStore
 import XCTest
 
-class OrdersWorkerTests: XCTestCase
-{
+class OrdersWorkerTests: XCTestCase {
   // MARK: Subject under test
   
   var sut: OrdersWorker!
   
   // MARK: Test lifecycle
   
-  override func setUp()
-  {
+  override func setUp() {
     super.setUp()
     setupOrdersWorker()
   }
   
-  override func tearDown()
-  {
+  override func tearDown() {
     super.tearDown()
   }
   
   // MARK: Test setup
   
-  func setupOrdersWorker()
-  {
+  func setupOrdersWorker() {
     sut = OrdersWorker(ordersStore: OrdersMemStoreSpy())
   }
   
   // MARK: Test doubles
   
-  class OrdersMemStoreSpy: OrdersMemStore
-  {
+  class OrdersMemStoreSpy: OrdersMemStore {
     // MARK: Method call expectations
     var fetchedOrdersCalled = false
     
@@ -52,8 +47,7 @@ class OrdersWorkerTests: XCTestCase
   
   // MARK: Tests
   
-  func testFetchOrdersShouldReturnListOfOrders()
-  {
+  func testFetchOrdersShouldReturnListOfOrders() {
     // Given
     let ordersMemStoreSpy = sut.ordersStore as! OrdersMemStoreSpy
     


### PR DESCRIPTION
Ray Wenderlich (among others) wrote a pretty good swift style guide:
https://github.com/raywenderlich/swift-style-guide

The main changes in Clean-Store are the OTBS bracing style and the split of protocol conformance into extensions (as seen in Approach 3 of the **Refactoring table view data source and delegate methods** blog entry at http://clean-swift.com/refactoring-table-view-data-source-and-delegate-methods/)
