### PR TITLE
Move shipment methods down to worker and introduce presenter for it

### DIFF
--- a/CleanStore/Scenes/CreateOrder/CreateOrderInteractor.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderInteractor.swift
@@ -14,17 +14,17 @@ import UIKit
 
 protocol CreateOrderBusinessLogic
 {
-  var shippingMethods: [String] { get }
   var orderToEdit: Order? { get set }
   func formatExpirationDate(request: CreateOrder.FormatExpirationDate.Request)
   func createOrder(request: CreateOrder.CreateOrder.Request)
   func showOrderToEdit(request: CreateOrder.EditOrder.Request)
   func updateOrder(request: CreateOrder.UpdateOrder.Request)
+  func fetchShipmentMethods(request: CreateOrder.FetchShipmentMethods.Request)
 }
 
 protocol CreateOrderDataStore
 {
-  var shippingMethods: [String] { get }
+  var shipmentMethods: [ShipmentMethod] { get }
   var orderToEdit: Order? { get set }
 }
 
@@ -33,11 +33,7 @@ class CreateOrderInteractor: CreateOrderBusinessLogic, CreateOrderDataStore
   var presenter: CreateOrderPresentationLogic?
   var ordersWorker = OrdersWorker(ordersStore: OrdersMemStore())
   var orderToEdit: Order?
-  var shippingMethods = [
-    ShipmentMethod(speed: .Standard).toString(),
-    ShipmentMethod(speed: .OneDay).toString(),
-    ShipmentMethod(speed: .TwoDay).toString()
-  ]
+  var shipmentMethods: [ShipmentMethod] = []
   
   // MARK: - Expiration date
   
@@ -78,6 +74,15 @@ class CreateOrderInteractor: CreateOrderBusinessLogic, CreateOrderDataStore
       self.orderToEdit = order
       let response = CreateOrder.UpdateOrder.Response(order: order)
       self.presenter?.presentUpdatedOrder(response: response)
+    }
+  }
+  
+  func fetchShipmentMethods(request: CreateOrder.FetchShipmentMethods.Request)
+  {
+    ordersWorker.fetchShipmentMethods { (shipmentMethods) -> Void in
+      self.shipmentMethods = shipmentMethods
+      let response = CreateOrder.FetchShipmentMethods.Response(shipmentMethods: shipmentMethods)
+      self.presenter?.presentFetchedShipmentMethods(response: response)
     }
   }
   

--- a/CleanStore/Scenes/CreateOrder/CreateOrderModels.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderModels.swift
@@ -114,4 +114,24 @@ enum CreateOrder
       var order: Order?
     }
   }
+  
+  enum FetchShipmentMethods
+  {
+    struct Request
+    {
+    }
+    struct Response
+    {
+      var shipmentMethods: [ShipmentMethod]
+    }
+    struct ViewModel
+    {
+      struct DisplayedShipmentMethod
+      {
+        var id: Int
+        var text: String
+      }
+      var displayedShipmentMethods: [DisplayedShipmentMethod]
+    }
+  }
 }

--- a/CleanStore/Scenes/CreateOrder/CreateOrderPresenter.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderPresenter.swift
@@ -18,6 +18,7 @@ protocol CreateOrderPresentationLogic
   func presentCreatedOrder(response: CreateOrder.CreateOrder.Response)
   func presentOrderToEdit(response: CreateOrder.EditOrder.Response)
   func presentUpdatedOrder(response: CreateOrder.UpdateOrder.Response)
+  func presentFetchedShipmentMethods(response: CreateOrder.FetchShipmentMethods.Response)
 }
 
 class CreateOrderPresenter: CreateOrderPresentationLogic
@@ -86,5 +87,21 @@ class CreateOrderPresenter: CreateOrderPresentationLogic
   {
     let viewModel = CreateOrder.UpdateOrder.ViewModel(order: response.order)
     viewController?.displayUpdatedOrder(viewModel: viewModel)
+  }
+  
+  // MARK: - Fetch orders
+  
+  func presentFetchedShipmentMethods(response: CreateOrder.FetchShipmentMethods.Response)
+  {
+    var displayedShipmentMethods: [CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod] = []
+    for shipmentMethod in response.shipmentMethods {
+      let displayedShipmentMethod = CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod(
+        id: shipmentMethod.speed.rawValue,
+        text: shipmentMethod.toString()
+      )
+      displayedShipmentMethods.append(displayedShipmentMethod)
+    }
+    let viewModel = CreateOrder.FetchShipmentMethods.ViewModel(displayedShipmentMethods: displayedShipmentMethods)
+    viewController?.displayFetchedShipmentMethods(viewModel: viewModel)
   }
 }

--- a/CleanStore/Scenes/CreateOrder/CreateOrderViewController.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderViewController.swift
@@ -18,12 +18,14 @@ protocol CreateOrderDisplayLogic: class
   func displayCreatedOrder(viewModel: CreateOrder.CreateOrder.ViewModel)
   func displayOrderToEdit(viewModel: CreateOrder.EditOrder.ViewModel)
   func displayUpdatedOrder(viewModel: CreateOrder.UpdateOrder.ViewModel)
+  func displayFetchedShipmentMethods(viewModel: CreateOrder.FetchShipmentMethods.ViewModel)
 }
 
 class CreateOrderViewController: UITableViewController, CreateOrderDisplayLogic, UITextFieldDelegate, UIPickerViewDataSource, UIPickerViewDelegate
 {
   var interactor: CreateOrderBusinessLogic?
   var router: (NSObjectProtocol & CreateOrderRoutingLogic & CreateOrderDataPassing)?
+  var displayedShipmentMethods: [CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod] = []
   
   // MARK: Object lifecycle
   
@@ -74,6 +76,7 @@ class CreateOrderViewController: UITableViewController, CreateOrderDisplayLogic,
     super.viewDidLoad()
     configurePickers()
     showOrderToEdit()
+    fetchShipmentMethodsOnLoad()
   }
   
   // MARK: - Text fields
@@ -121,17 +124,31 @@ class CreateOrderViewController: UITableViewController, CreateOrderDisplayLogic,
   
   func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int
   {
-    return interactor?.shippingMethods.count ?? 0
+    return displayedShipmentMethods.count
   }
   
   func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String?
   {
-    return interactor?.shippingMethods[row]
+    return displayedShipmentMethods[row].text
   }
   
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int)
   {
-    shippingMethodTextField.text = interactor?.shippingMethods[row]
+    shippingMethodTextField.text = displayedShipmentMethods[row].text
+  }
+  
+  // MARK: - Fetch shipment methods
+  
+  func fetchShipmentMethodsOnLoad()
+  {
+    let request = CreateOrder.FetchShipmentMethods.Request()
+    interactor?.fetchShipmentMethods(request: request)
+  }
+  
+  func displayFetchedShipmentMethods(viewModel: CreateOrder.FetchShipmentMethods.ViewModel)
+  {
+    displayedShipmentMethods = viewModel.displayedShipmentMethods
+    shippingMethodPicker.reloadAllComponents()
   }
   
   // MARK: - Expiration date

--- a/CleanStore/Services/OrdersAPI.swift
+++ b/CleanStore/Services/OrdersAPI.swift
@@ -24,6 +24,10 @@ class OrdersAPI: OrdersStoreProtocol, OrdersStoreUtilityProtocol
   {
   }
   
+  func fetchShipmentMethods(completionHandler: @escaping ([ShipmentMethod], OrdersStoreError?) -> Void)
+  {
+  }
+  
   // MARK: - CRUD operations - Generic enum result type
   
   func fetchOrders(completionHandler: @escaping OrdersStoreFetchOrdersCompletionHandler)
@@ -46,6 +50,10 @@ class OrdersAPI: OrdersStoreProtocol, OrdersStoreUtilityProtocol
   {
   }
   
+  func fetchShipmentMethods(completionHandler: @escaping OrdersStoreFetchShipmentMethodsCompletionHandler)
+  {
+  }
+  
   // MARK: - CRUD operations - Inner closure
   
   func fetchOrders(completionHandler: @escaping (() throws -> [Order]) -> Void)
@@ -65,6 +73,10 @@ class OrdersAPI: OrdersStoreProtocol, OrdersStoreUtilityProtocol
   }
   
   func deleteOrder(id: String, completionHandler: @escaping (() throws -> Order?) -> Void)
+  {
+  }
+  
+  func fetchShipmentMethods(completionHandler: @escaping (() throws -> [ShipmentMethod]) -> Void)
   {
   }
 }

--- a/CleanStore/Services/OrdersCoreDataStore.swift
+++ b/CleanStore/Services/OrdersCoreDataStore.swift
@@ -149,6 +149,11 @@ class OrdersCoreDataStore: OrdersStoreProtocol, OrdersStoreUtilityProtocol
     }
   }
   
+  func fetchShipmentMethods(completionHandler: @escaping ([ShipmentMethod], OrdersStoreError?) -> Void)
+  {
+    fatalError("Not implemented")
+  }
+  
   // MARK: - CRUD operations - Generic enum result type
   
   func fetchOrders(completionHandler: @escaping OrdersStoreFetchOrdersCompletionHandler)
@@ -249,6 +254,11 @@ class OrdersCoreDataStore: OrdersStoreProtocol, OrdersStoreUtilityProtocol
     }
   }
   
+  func fetchShipmentMethods(completionHandler: @escaping OrdersStoreFetchShipmentMethodsCompletionHandler)
+  {
+    fatalError("Not implemented")
+  }
+  
   // MARK: - CRUD operations - Inner closure
   
   func fetchOrders(completionHandler: @escaping (() throws -> [Order]) -> Void)
@@ -346,5 +356,10 @@ class OrdersCoreDataStore: OrdersStoreProtocol, OrdersStoreUtilityProtocol
         completionHandler { throw OrdersStoreError.CannotDelete("Cannot fetch order with id \(id) to delete") }
       }
     }
+  }
+  
+  func fetchShipmentMethods(completionHandler: @escaping (() throws -> [ShipmentMethod]) -> Void)
+  {
+    fatalError("Not implemented")
   }
 }

--- a/CleanStore/Services/OrdersMemStore.swift
+++ b/CleanStore/Services/OrdersMemStore.swift
@@ -14,6 +14,12 @@ class OrdersMemStore: OrdersStoreProtocol, OrdersStoreUtilityProtocol
     Order(firstName: "Bob", lastName: "Battery", phone: "222-222-2222", email: "bob.battery@clean-swift.com", billingAddress: billingAddress, paymentMethod: paymentMethod, shipmentAddress: shipmentAddress, shipmentMethod: shipmentMethod, id: "def456", date: Date(), total: NSDecimalNumber(string: "4.56"))
   ]
   
+  static var shipmentMethods = [
+    ShipmentMethod(speed: .Standard),
+    ShipmentMethod(speed: .OneDay),
+    ShipmentMethod(speed: .TwoDay)
+  ]
+  
   // MARK: - CRUD operations - Optional error
   
   func fetchOrders(completionHandler: @escaping ([Order], OrdersStoreError?) -> Void)
@@ -59,6 +65,11 @@ class OrdersMemStore: OrdersStoreProtocol, OrdersStoreUtilityProtocol
       return
     }
     completionHandler(nil, OrdersStoreError.CannotDelete("Cannot fetch order with id \(id) to delete"))
+  }
+  
+  func fetchShipmentMethods(completionHandler: @escaping ([ShipmentMethod], OrdersStoreError?) -> Void)
+  {
+    completionHandler(type(of: self).shipmentMethods, nil)
   }
   
   // MARK: - CRUD operations - Generic enum result type
@@ -110,6 +121,11 @@ class OrdersMemStore: OrdersStoreProtocol, OrdersStoreUtilityProtocol
     completionHandler(OrdersStoreResult.Failure(error: OrdersStoreError.CannotDelete("Cannot delete order with id \(id) to delete")))
   }
   
+  func fetchShipmentMethods(completionHandler: @escaping OrdersStoreFetchShipmentMethodsCompletionHandler)
+  {
+    completionHandler(OrdersStoreResult.Success(result: type(of: self).shipmentMethods))
+  }
+  
   // MARK: - CRUD operations - Inner closure
   
   func fetchOrders(completionHandler: @escaping (() throws -> [Order]) -> Void)
@@ -154,6 +170,11 @@ class OrdersMemStore: OrdersStoreProtocol, OrdersStoreUtilityProtocol
     } else {
       completionHandler { throw OrdersStoreError.CannotDelete("Cannot fetch order with id \(id) to delete") }
     }
+  }
+  
+  func fetchShipmentMethods(completionHandler: @escaping (() throws -> [ShipmentMethod]) -> Void)
+  {
+    completionHandler { return type(of: self).shipmentMethods }
   }
   
   // MARK: - Convenience methods

--- a/CleanStore/Workers/OrdersWorker.swift
+++ b/CleanStore/Workers/OrdersWorker.swift
@@ -58,6 +58,22 @@ class OrdersWorker
       }
     }
   }
+  
+  func fetchShipmentMethods(completionHandler: @escaping ([ShipmentMethod]) -> Void)
+  {
+    ordersStore.fetchShipmentMethods { (shipmentMethod: () throws -> [ShipmentMethod]) -> Void in
+      do {
+        let shipmentMethods = try shipmentMethod()
+        DispatchQueue.main.async {
+          completionHandler(shipmentMethods)
+        }
+      } catch {
+        DispatchQueue.main.async {
+          completionHandler([])
+        }
+      }
+    }
+  }
 }
 
 // MARK: - Orders store API
@@ -71,6 +87,7 @@ protocol OrdersStoreProtocol
   func createOrder(orderToCreate: Order, completionHandler: @escaping (Order?, OrdersStoreError?) -> Void)
   func updateOrder(orderToUpdate: Order, completionHandler: @escaping (Order?, OrdersStoreError?) -> Void)
   func deleteOrder(id: String, completionHandler: @escaping (Order?, OrdersStoreError?) -> Void)
+  func fetchShipmentMethods(completionHandler: @escaping ([ShipmentMethod], OrdersStoreError?) -> Void)
   
   // MARK: CRUD operations - Generic enum result type
   
@@ -79,6 +96,7 @@ protocol OrdersStoreProtocol
   func createOrder(orderToCreate: Order, completionHandler: @escaping OrdersStoreCreateOrderCompletionHandler)
   func updateOrder(orderToUpdate: Order, completionHandler: @escaping OrdersStoreUpdateOrderCompletionHandler)
   func deleteOrder(id: String, completionHandler: @escaping OrdersStoreDeleteOrderCompletionHandler)
+  func fetchShipmentMethods(completionHandler: @escaping OrdersStoreFetchShipmentMethodsCompletionHandler)
   
   // MARK: CRUD operations - Inner closure
   
@@ -87,6 +105,7 @@ protocol OrdersStoreProtocol
   func createOrder(orderToCreate: Order, completionHandler: @escaping (() throws -> Order?) -> Void)
   func updateOrder(orderToUpdate: Order, completionHandler: @escaping (() throws -> Order?) -> Void)
   func deleteOrder(id: String, completionHandler: @escaping (() throws -> Order?) -> Void)
+  func fetchShipmentMethods(completionHandler: @escaping (() throws -> [ShipmentMethod]) -> Void)
 }
 
 protocol OrdersStoreUtilityProtocol {}
@@ -113,6 +132,7 @@ typealias OrdersStoreFetchOrderCompletionHandler = (OrdersStoreResult<Order>) ->
 typealias OrdersStoreCreateOrderCompletionHandler = (OrdersStoreResult<Order>) -> Void
 typealias OrdersStoreUpdateOrderCompletionHandler = (OrdersStoreResult<Order>) -> Void
 typealias OrdersStoreDeleteOrderCompletionHandler = (OrdersStoreResult<Order>) -> Void
+typealias OrdersStoreFetchShipmentMethodsCompletionHandler = (OrdersStoreResult<[ShipmentMethod]>) -> Void
 
 enum OrdersStoreResult<U>
 {

--- a/CleanStoreTests/Scenes/CreateOrder/CreateOrderPresenterTests.swift
+++ b/CleanStoreTests/Scenes/CreateOrder/CreateOrderPresenterTests.swift
@@ -50,6 +50,7 @@ class CreateOrderPresenterTests: XCTestCase
     var displayCreatedOrderCalled = false
     var displayOrderToEditCalled = false
     var displayUpdatedOrderCalled = false
+    var displayFetchedShipmentMethodsCalled = false
     
     // MARK: Argument expectations
     
@@ -57,6 +58,7 @@ class CreateOrderPresenterTests: XCTestCase
     var createOrderViewModel: CreateOrder.CreateOrder.ViewModel!
     var editOrderViewModel: CreateOrder.EditOrder.ViewModel!
     var updateOrderViewModel: CreateOrder.UpdateOrder.ViewModel!
+    var fetchedShipmentMethodsViewModel: CreateOrder.FetchShipmentMethods.ViewModel!
     
     // MARK: Spied methods
     
@@ -82,6 +84,12 @@ class CreateOrderPresenterTests: XCTestCase
     {
       displayUpdatedOrderCalled = true
       self.updateOrderViewModel = viewModel
+    }
+    
+    func displayFetchedShipmentMethods(viewModel: CreateOrder.FetchShipmentMethods.ViewModel)
+    {
+      displayFetchedShipmentMethodsCalled = true
+      self.fetchedShipmentMethodsViewModel = viewModel
     }
   }
   
@@ -93,6 +101,7 @@ class CreateOrderPresenterTests: XCTestCase
     var displayCreatedOrderCalled = false
     var displayOrderToEditCalled = false
     var displayUpdatedOrderCalled = false
+    var displayFetchedShipmentMethodsCalled = false
     
     // MARK: Argument expectations
     
@@ -100,6 +109,7 @@ class CreateOrderPresenterTests: XCTestCase
     var createOrderViewModel: CreateOrder.CreateOrder.ViewModel!
     var editOrderViewModel: CreateOrder.EditOrder.ViewModel!
     var updateOrderViewModel: CreateOrder.UpdateOrder.ViewModel!
+    var fetchedShipmentMethodsViewModel: CreateOrder.FetchShipmentMethods.ViewModel!
     
     // MARK: Spied methods
     
@@ -125,6 +135,12 @@ class CreateOrderPresenterTests: XCTestCase
     {
       displayUpdatedOrderCalled = true
       self.updateOrderViewModel = viewModel
+    }
+    
+    func displayFetchedShipmentMethods(viewModel: CreateOrder.FetchShipmentMethods.ViewModel)
+    {
+      displayFetchedShipmentMethodsCalled = true
+      self.fetchedShipmentMethodsViewModel = viewModel
     }
     
     // MARK: Verifications

--- a/CleanStoreTests/Scenes/CreateOrder/CreateOrderViewControllerTests.swift
+++ b/CleanStoreTests/Scenes/CreateOrder/CreateOrderViewControllerTests.swift
@@ -76,6 +76,7 @@ class CreateOrderViewControllerTests: XCTestCase
     var createOrderCalled = false
     var showOrderToEditCalled = false
     var updateOrderCalled = false
+    var presentFetchedShipmentMethodsCalled = false
     
     // MARK: Argument expectations
     
@@ -83,10 +84,11 @@ class CreateOrderViewControllerTests: XCTestCase
     var createOrderRequest: CreateOrder.CreateOrder.Request!
     var editOrderRequest: CreateOrder.EditOrder.Request!
     var updateOrderRequest: CreateOrder.UpdateOrder.Request!
+    var fetchShipmentMethodsRequest: CreateOrder.FetchShipmentMethods.Request!
     
     // MARK: Spied variables
     
-    var shippingMethods = [String]()
+    var shippingMethods = [ShipmentMethod]()
     var orderToEdit: Order?
     
     // MARK: Spied methods
@@ -113,6 +115,12 @@ class CreateOrderViewControllerTests: XCTestCase
     {
       updateOrderCalled = true
       self.updateOrderRequest = request
+    }
+    
+    func fetchShipmentMethods(request: CreateOrder.FetchShipmentMethods.Request)
+    {
+      presentFetchedShipmentMethodsCalled = true
+      self.fetchShipmentMethodsRequest = request
     }
   }
   
@@ -246,13 +254,14 @@ class CreateOrderViewControllerTests: XCTestCase
     // Given
     loadView()
     let pickerView = sut.shippingMethodPicker!
+    let testShipmentMethods = [CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod(id: 1, text: "Some Shipping")]
+    sut.displayedShipmentMethods = testShipmentMethods
     
     // When
     let numberOfRows = sut.pickerView(pickerView, numberOfRowsInComponent: 0)
     
     // Then
-    let numberOfAvailableShippingtMethods = sut.interactor?.shippingMethods.count
-    XCTAssertEqual(numberOfRows, numberOfAvailableShippingtMethods, "The number of rows in the first component of shipping method picker should equal to the number of available shipping methods")
+    XCTAssertEqual(numberOfRows, testShipmentMethods.count, "The number of rows in the first component of shipping method picker should equal to the number of available shipping methods")
   }
   
   func testShippingMethodPickerShouldDisplayProperTitles()
@@ -261,7 +270,17 @@ class CreateOrderViewControllerTests: XCTestCase
     loadView()
     let pickerView = sut.shippingMethodPicker!
     
+    let displayedShipmentMethods = [
+        CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod(id: 1, text: "Standard Shipping"),
+        CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod(id: 2, text: "One-Day Shipping"),
+        CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod(id: 3, text: "Two-Day Shipping")
+    ]
+    
+    let viewModel = CreateOrder.FetchShipmentMethods.ViewModel(displayedShipmentMethods: displayedShipmentMethods)
+    
     // When
+    sut.displayFetchedShipmentMethods(viewModel: viewModel)
+    
     let returnedTitles = [
       sut.pickerView(pickerView, titleForRow: 0, forComponent: 0),
       sut.pickerView(pickerView, titleForRow: 1, forComponent: 0),
@@ -285,7 +304,16 @@ class CreateOrderViewControllerTests: XCTestCase
     loadView()
     let pickerView = sut.shippingMethodPicker!
     
+    let displayedShipmentMethods = [
+        CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod(id: 1, text: "Standard Shipping"),
+        CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod(id: 2, text: "One-Day Shipping"),
+        CreateOrder.FetchShipmentMethods.ViewModel.DisplayedShipmentMethod(id: 3, text: "Two-Day Shipping")
+    ]
+    
+    let viewModel = CreateOrder.FetchShipmentMethods.ViewModel(displayedShipmentMethods: displayedShipmentMethods)
+    
     // When
+    sut.displayFetchedShipmentMethods(viewModel: viewModel)
     sut.pickerView(pickerView, didSelectRow: 1, inComponent: 0)
     
     // Then

--- a/CleanStoreTests/Seeds.swift
+++ b/CleanStoreTests/Seeds.swift
@@ -14,4 +14,13 @@ struct Seeds
     static let bob = Order(firstName: "Bob", lastName: "Battery", phone: "222-222-2222", email: "bob.battery@clean-swift.com", billingAddress: billingAddress, paymentMethod: paymentMethod, shipmentAddress: shipmentAddress, shipmentMethod: shipmentMethod, id: "bbb222", date: Date(), total: NSDecimalNumber(string: "2.22"))
     static let chris = Order(firstName: "Chris", lastName: "Camera", phone: "333-333-3333", email: "chris.camera@clean-swift.com", billingAddress: billingAddress, paymentMethod: paymentMethod, shipmentAddress: shipmentAddress, shipmentMethod: shipmentMethod, id: "ccc333", date: Date(), total: NSDecimalNumber(string: "3.33"))
   }
+  
+  struct ShipmentMethods
+  {
+    static let all = [
+        ShipmentMethod(speed: .Standard),
+        ShipmentMethod(speed: .OneDay),
+        ShipmentMethod(speed: .TwoDay)
+    ]
+  }
 }


### PR DESCRIPTION
For the shipment method picker in create order scene, the view controller currently requests and receives from the interactor. However, this violates the uni-directional flow, am I understanding this correctly that it should be this?:

1. View controller send the request to the interactor
2. Interactor requests shipment methods from worker / storage
3. Worker sends it back to the interactor
4. Interactor sends it back to the presenter
5. Presenter formats, localizes, etc then sends it back to view controller