### PR TITLE
Convert view models from structs to tuples

### DIFF
--- a/CleanStore/Scenes/CreateOrder/CreateOrderModels.swift
+++ b/CleanStore/Scenes/CreateOrder/CreateOrderModels.swift
@@ -14,41 +14,41 @@ import UIKit
 
 enum CreateOrder
 {
-  struct OrderFormFields
-  {
+  typealias OrderFormFields =
+  (
     // MARK: Contact info
-    var firstName: String
-    var lastName: String
-    var phone: String
-    var email: String
+    firstName: String,
+    lastName: String,
+    phone: String,
+    email: String,
     
     // MARK: Payment info
-    var billingAddressStreet1: String
-    var billingAddressStreet2: String
-    var billingAddressCity: String
-    var billingAddressState: String
-    var billingAddressZIP: String
+    billingAddressStreet1: String,
+    billingAddressStreet2: String,
+    billingAddressCity: String,
+    billingAddressState: String,
+    billingAddressZIP: String,
     
-    var paymentMethodCreditCardNumber: String
-    var paymentMethodCVV: String
-    var paymentMethodExpirationDate: Date
-    var paymentMethodExpirationDateString: String
+    paymentMethodCreditCardNumber: String,
+    paymentMethodCVV: String,
+    paymentMethodExpirationDate: Date,
+    paymentMethodExpirationDateString: String,
     
     // MARK: Shipping info
-    var shipmentAddressStreet1: String
-    var shipmentAddressStreet2: String
-    var shipmentAddressCity: String
-    var shipmentAddressState: String
-    var shipmentAddressZIP: String
+    shipmentAddressStreet1: String,
+    shipmentAddressStreet2: String,
+    shipmentAddressCity: String,
+    shipmentAddressState: String,
+    shipmentAddressZIP: String,
     
-    var shipmentMethodSpeed: Int
-    var shipmentMethodSpeedString: String
+    shipmentMethodSpeed: Int,
+    shipmentMethodSpeedString: String,
     
     // MARK: Misc
-    var id: String?
-    var date: Date
-    var total: NSDecimalNumber
-  }
+    id: String?,
+    date: Date,
+    total: NSDecimalNumber
+  )
   
   // MARK: Use cases
   

--- a/CleanStore/Scenes/ListOrders/ListOrdersModels.swift
+++ b/CleanStore/Scenes/ListOrders/ListOrdersModels.swift
@@ -27,14 +27,14 @@ enum ListOrders
     }
     struct ViewModel
     {
-      struct DisplayedOrder
-      {
-        var id: String
-        var date: String
-        var email: String
-        var name: String
-        var total: String
-      }
+      typealias DisplayedOrder =
+      (
+        id: String,
+        date: String,
+        email: String,
+        name: String,
+        total: String
+      )
       var displayedOrders: [DisplayedOrder]
     }
   }

--- a/CleanStore/Scenes/ShowOrder/ShowOrderModels.swift
+++ b/CleanStore/Scenes/ShowOrder/ShowOrderModels.swift
@@ -27,14 +27,14 @@ enum ShowOrder
     }
     struct ViewModel
     {
-      struct DisplayedOrder
-      {
-        var id: String
-        var date: String
-        var email: String
-        var name: String
-        var total: String
-      }
+      typealias DisplayedOrder =
+      (
+        id: String,
+        date: String,
+        email: String,
+        name: String,
+        total: String
+      )
       var displayedOrder: DisplayedOrder
     }
   }


### PR DESCRIPTION
In an effort to make view models almost as dumb as enums, how about using tuples over structs?

Benefits I see:
1. Disallow `func`, `init`, and other logic
2. Get equatable for free (https://github.com/apple/swift-evolution/blob/master/proposals/0015-tuple-comparison-operators.md)
3. Access members by index?

Can you think of any issues or implications of this (performance, memory, etc)?

Further discussions: https://stackoverflow.com/questions/27384151/swift-tuples-different-from-struct-and-from-each-other