### PR TITLE
Remove unnecessary explicit conformance to Equatable

### DIFF
--- a/CleanStore/Models/Order.swift
+++ b/CleanStore/Models/Order.swift
@@ -30,24 +30,9 @@ struct Order: Equatable
   var total: NSDecimalNumber
 }
 
-func ==(lhs: Order, rhs: Order) -> Bool
-{
-  return lhs.firstName == rhs.firstName
-    && lhs.lastName == rhs.lastName
-    && lhs.phone == rhs.phone
-    && lhs.email == rhs.email
-    && lhs.billingAddress == rhs.billingAddress
-    && lhs.paymentMethod == rhs.paymentMethod
-    && lhs.shipmentAddress == rhs.shipmentAddress
-    && lhs.shipmentMethod == rhs.shipmentMethod
-    && lhs.id == rhs.id
-    && lhs.date.timeIntervalSince(rhs.date) < 1.0
-    && lhs.total == rhs.total
-}
-
 // MARK: - Supporting models
 
-struct Address
+struct Address: Equatable
 {
   var street1: String
   var street2: String?
@@ -56,16 +41,7 @@ struct Address
   var zip: String
 }
 
-func ==(lhs: Address, rhs: Address) -> Bool
-{
-  return lhs.street1 == rhs.street1
-    && lhs.street2 == rhs.street2
-    && lhs.city == rhs.city
-    && lhs.state == rhs.state
-    && lhs.zip == rhs.zip
-}
-
-struct ShipmentMethod
+struct ShipmentMethod: Equatable
 {
   enum ShippingSpeed: Int {
     case Standard = 0 // "Standard Shipping"
@@ -87,21 +63,9 @@ struct ShipmentMethod
   }
 }
 
-func ==(lhs: ShipmentMethod, rhs: ShipmentMethod) -> Bool
-{
-  return lhs.speed == rhs.speed
-}
-
-struct PaymentMethod
+struct PaymentMethod: Equatable
 {
   var creditCardNumber: String
   var expirationDate: Date
   var cvv: String
-}
-
-func ==(lhs: PaymentMethod, rhs: PaymentMethod) -> Bool
-{
-  return lhs.creditCardNumber == rhs.creditCardNumber
-    && lhs.expirationDate.timeIntervalSince(rhs.expirationDate) < 1.0
-    && lhs.cvv == rhs.cvv
 }

--- a/CleanStore/Workers/OrdersWorker.swift
+++ b/CleanStore/Workers/OrdersWorker.swift
@@ -135,14 +135,3 @@ enum OrdersStoreError: Equatable, Error
   case CannotUpdate(String)
   case CannotDelete(String)
 }
-
-func ==(lhs: OrdersStoreError, rhs: OrdersStoreError) -> Bool
-{
-  switch (lhs, rhs) {
-  case (.CannotFetch(let a), .CannotFetch(let b)) where a == b: return true
-  case (.CannotCreate(let a), .CannotCreate(let b)) where a == b: return true
-  case (.CannotUpdate(let a), .CannotUpdate(let b)) where a == b: return true
-  case (.CannotDelete(let a), .CannotDelete(let b)) where a == b: return true
-  default: return false
-  }
-}

--- a/CleanStoreTests/Workers/OrdersWorkerTests.swift
+++ b/CleanStoreTests/Workers/OrdersWorkerTests.swift
@@ -57,7 +57,7 @@ class OrdersWorkerTests: XCTestCase
       createOrderCalled = true
       DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
         completionHandler { () -> Order in
-          return OrdersWorkerTests.testOrders.first!
+          return orderToCreate
         }
       }
     }
@@ -67,7 +67,7 @@ class OrdersWorkerTests: XCTestCase
       updateOrderCalled = true
       DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
         completionHandler { () -> Order in
-          return OrdersWorkerTests.testOrders.first!
+          return orderToUpdate
         }
       }
     }


### PR DESCRIPTION
I noticed that the models in `Order.swift` explicitly implement the `==` function to conform to `Equatable`. This means that each time a model is updated, this method must be updated too, which makes it easy to make a mistake by forgetting to do so. This could be avoided by making all properties inside the models conform to `Equatable` too.
Also, `lhs.date.timeIntervalSince(rhs.date) < 1.0` comparison wasn't working correctly because for each case when `rhs` is later than `lhs` it would always return true.
This also revealed an error in the Unit Tests when `OrdersWorker.updateOrder` method wasn't returning the correct order with the updated date in it.
Therefore I have:
- Removed all instances of explicitly implemented `==` method
- Declared necessary Model structs as conforming to `Equatable`
- Made `updateOrder` method inside `OrdersWorkerTests` test suite return the `Order` object passed to it inside the `completionHandler` instead of the static mock object from `OrdersWorkerTests.testOrders`